### PR TITLE
Avoid redirection loop on /ameli

### DIFF
--- a/app/js/controllers/homepage.js
+++ b/app/js/controllers/homepage.js
@@ -13,7 +13,10 @@ angular.module('ddsApp').controller('HomepageCtrl', function($scope, $state, $se
 
     var referrer = document.referrer;
     if (referrer.match(/ameli\.fr/)) {
-        $state.go('ameli');
+        if (! $sessionStorage.ameliNoticationDone) {
+            $sessionStorage.ameliNoticationDone = true;
+            $state.go('ameli');
+        }
     } else if (_.some(phishingExpressions, function(phishingExpression) { return referrer.match(phishingExpression); })) {
         if (! $sessionStorage.phishingNoticationDone) {
             $sessionStorage.phishingNoticationDone = true;


### PR DESCRIPTION
Les personnes provenant du site ameli.fr sont redirigés vers une page lui expliquant qu'ils ont arrivé là pour de mauvaises raisons et qu'ils sont au mauvais endroit.

En continuant leur navigation sur le site, l'accès à la page d'accueil leur est interdit car ils sont automatique redirigés vers la page spécifique.