### PR TITLE
[Fix] Migrate situationsFamiliales enum to new syntax

### DIFF
--- a/app/js/constants/situationsFamiliales.js
+++ b/app/js/constants/situationsFamiliales.js
@@ -2,15 +2,15 @@
 
 angular.module('ddsCommon').constant('situationsFamiliales', [
     {
-        value: 'Marié',  // Enum value 1 in OpenFisca
+        value: 'marie',  // Enum value 1 in OpenFisca
         label: 'Marié(e)',
     },
     {
-        value: 'Pacsé',  // Enum value 5 in OpenFisca
+        value: 'pacse',  // Enum value 5 in OpenFisca
         label: 'Pacsé(e)',
     },
     {
-        value: 'Célibataire',  // Enum value 2 in OpenFisca
+        value: 'celibataire',  // Enum value 2 in OpenFisca
         label: 'En union libre',
     }
 ]);


### PR DESCRIPTION
Considering the error's message:

> `Célibataire` is not a valid enum value for path `statut_marital`"

and the enum's values displayed 3 lines below in the same error :
```
"enumValues": [
  "marie",
  "pacse",
  "celibataire"
],
```
I think that a rename was missed in [Migrate statut_marital enumeration](https://github.com/betagouv/mes-aides-ui/commit/fe92fc675e3a1ef31a6a8a787513a89bb0536187)

<img width="1088" alt="broken_statut_marital" src="https://user-images.githubusercontent.com/181349/35541615-ea2b793a-055b-11e8-9e03-b5d37c1e9912.png">