### PR TITLE
Lien direct vers Retour en France

### DIFF
--- a/app/views/partials/foyer/logement.html
+++ b/app/views/partials/foyer/logement.html
@@ -1,5 +1,10 @@
 <div class="frame-foyer">
   <h1>Votre logement principal</h1>
+
+  <div class="help-block">
+    <p>Si vous habitez actuellement à l'étranger, préférez le simulateur <a target="_blank" rel="noopener" href="http://retour-en-france.simplicite.fr/">Retour en France</a>. Des délais de résidence en France sont en effet requis pour certaines aides.</p>
+  </div>
+
   <form method="post" name="form" class="form-horizontal" novalidate ng-submit="submit(form)">
 
     <div class="form-group">


### PR DESCRIPTION
Ajout d'un lien vers le simulateur Retour en France sur la page du choix du logement.

Should fix https://github.com/betagouv/mes-aides-ui/issues/743 .