### PR TITLE
Bind missing function into scope.

### DIFF
--- a/app/js/directives/individuBlock.js
+++ b/app/js/directives/individuBlock.js
@@ -10,6 +10,7 @@ angular.module('ddsCommon').directive('individuBlock', function(IndividuService)
         controller: function($scope) {
             $scope.individuLabel = IndividuService.label;
             $scope.nationalite = IndividuService.nationaliteLabel;
+            $scope.statutsSpecifiques = IndividuService.formatStatutsSpecifiques;
             var sref = function(individu) {
                 switch (individu.role) {
                     case 'demandeur':


### PR DESCRIPTION
Actually the function was _already_ called in [`individu-block.html`](https://github.com/betagouv/mes-aides-ui/blob/f10ebfe5f3e74993081b6ae5469e34ab648d4ad5/app/views/partials/individu-block.html#L13) 🙃

<img width="298" alt="capture d ecran 2018-05-15 a 17 12 21" src="https://user-images.githubusercontent.com/1162230/40065906-2bc7fa1c-5863-11e8-9fa1-2f9ba1a0f364.png">
