### PR TITLE
Bourse de lycée : dates 2018

### DIFF
--- a/app/js/constants/droits.js
+++ b/app/js/constants/droits.js
@@ -346,13 +346,13 @@ var droitsDescription = {
                     'shortLabel': 'Bourse col',
                     'description': 'La bourse de collège est une aide destinée à favoriser la scolarité des collégiens. Elle est versée aux familles ayant de faibles ressources. Son montant dépend du nombre d’enfants à charge.',
                     conditions: [
-                        'Déposer votre dossier avant octobre 2017 pour l’année scolaire 2017-2018.',
                         'Déposer votre dossier à partir de l’été 2018 pour l’année scolaire 2018-2019.',
+                        'Pour les élèves scolarisés en collège public, la demande se fait en ligne sur le portail Scolarité Services de votre établissement.',
                     ],
                     'link': 'https://www.service-public.fr/particuliers/vosdroits/F984',
-                    'form': 'https://www.formulaires.modernisation.gouv.fr/gf/cerfa_12539.do',
+                    'instructions': 'http://www.education.gouv.fr/cid117994/scolarite-services-aide-a-la-premiere-connexion-des-parents.html',
                     'forms': {
-                        '2016-17': 'https://www.formulaires.modernisation.gouv.fr/gf/cerfa_12539.do'
+                        '2017-18': 'https://www.formulaires.modernisation.gouv.fr/gf/cerfa_12539.do',
                     },
                     'isBaseRessourcesYearMoins2': true
                 },
@@ -362,13 +362,14 @@ var droitsDescription = {
                     'shortLabel': 'Bourse lyc',
                     'description': 'La bourse de lycée est accordée aux responsables d’un lycéen qui ont de faibles ressources. Si l’élève entre au lycée ou s’il n’a jamais touché de bourse de lycée, il pourra y prétendre selon les ressources et les charges de sa famille. Une nouvelle demande doit être effectuée en cas de redoublement ou réorientation.',
                     conditions: [
-                        'Déposer votre dossier avant juillet 2017 pour l’année scolaire 2017-2018.',
-                        'Déposer votre dossier à partir du printemps 2018 pour l’année scolaire 2018-2019.',
+                        'Déposer votre dossier avant le 20 juin 2018 pour l’année scolaire 2018-2019.',
+                        'Pour les élèves scolarisés en lycée public, la demande se fait en ligne sur le portail Scolarité-Services',
                     ],
                     'link': 'https://www.service-public.fr/particuliers/vosdroits/F616',
                     'form': 'https://www.formulaires.modernisation.gouv.fr/gf/cerfa_11319.do',
                     'forms': {
-                        '2017-18': 'https://www.formulaires.modernisation.gouv.fr/gf/cerfa_11319.do'
+                        '2017-18': 'https://www.formulaires.modernisation.gouv.fr/gf/cerfa_11319.do',
+                        '2018-19': 'https://www.formulaires.modernisation.gouv.fr/gf/cerfa_11319.do',
                     },
                     'isBaseRessourcesYearMoins2': true
                 },


### PR DESCRIPTION
Ajout des dates concernant la bourse de lycée 2018-2019
Suppression des références à 2017-2018 pour ne pas entretenir de confusion