### PR TITLE
Nombre de prestations dynamiques dans les tags meta

### DIFF
--- a/app/views/front.html
+++ b/app/views/front.html
@@ -35,8 +35,8 @@
 
     <meta name="description" content="Ce questionnaire en ligne simple vous donnera un montant mensuel pour chaque prestation et vous donnera accès aux démarches.">
 
-    <meta name="og:description" content="7 minutes suffisent pour simuler vos droits à 27 prestations sociales.">
-    <meta name="twitter:description" content="7 minutes suffisent pour simuler vos droits à 27 prestations sociales.">
+    <meta name="og:description" content="7 minutes suffisent pour simuler vos droits à {{ prestationsCount }} prestations sociales.">
+    <meta name="twitter:description" content="7 minutes suffisent pour simuler vos droits à {{ prestationsCount }} prestations sociales.">
 
     <link rel="canonical" href="https://mes-aides.gouv.fr">
     <meta property="og:url" content="https://mes-aides.gouv.fr">

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bower": "^1.4.1",
     "cleave.js": "~0.7.15",
     "codes-postaux": "etalab/codes-postaux#003ea027941e7a40c6094c7a02e7299d37619712",
+    "consolidate": "^0.15.1",
     "d3": "4.11.0",
     "event-stream": "^3.1.7",
     "express": "~4.15.0",


### PR DESCRIPTION
Lorsqu'on ajoute une nouvelle prestation, il faut modifier les valeurs hardcodées pour que les tests passent. Cette Pull Request permet de rendre le chiffre dynamique. 