### PR TITLE
Actually make watch for Express files work.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,9 +78,10 @@ module.exports = function (grunt) {
       express: {
         files: [
           'server.js',
-          'index.js'
+          'index.js',
+          'backend/**/*.js'
         ],
-        tasks: ['newer:jshint:node', 'express:dev', 'wait'],
+        tasks: ['express:dev', 'wait'],
         options: {
           livereload: true,
           nospawn: true //Without this option specified express won't be reloaded

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,7 +79,8 @@ module.exports = function (grunt) {
         files: [
           'server.js',
           'index.js',
-          'backend/**/*.js'
+          'backend/**/*.js',
+          'app/js/constant/**/*.js',
         ],
         tasks: ['express:dev', 'wait'],
         options: {

--- a/backend/lib/openfisca/mapping/individu/proxyAnneeDeReferenceRessources.js
+++ b/backend/lib/openfisca/mapping/individu/proxyAnneeDeReferenceRessources.js
@@ -3,7 +3,7 @@ var moment = require('moment');
 
 var common = require('../common');
 var individuRessources = require('./ressources');
-var ressources = require('../../../../../app/js/constants/ressources.js');
+var ressources = require('../../../../../app/js/constants/ressources');
 
 var ressourcesToDuplicate = _.concat(
     Object.keys(individuRessources.computedRessources),

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "grunt-htmlrefs": "^0.5.0",
     "grunt-jscs": "^3.0.1",
     "grunt-karma": "~2.0.0",
-    "grunt-newer": "^1.2.0",
     "grunt-ng-annotate": "^3.0.0",
     "grunt-node-inspector": "~0.4.2",
     "grunt-nodemon": "~0.4.0",

--- a/test/backend/aidesDescription.js
+++ b/test/backend/aidesDescription.js
@@ -2,7 +2,7 @@ var expect = require('expect');
 
 
 describe('aides descriptions', function() {
-    var subject = require('../../app/js/constants/droits.js');
+    var subject = require('../../app/js/constants/droits');
 
     Object.keys(subject.prestationsNationales).forEach(function(providerName) {
         describe(providerName, function() {


### PR DESCRIPTION
Since e554c6fc3afcb9c275c0b9da2b6063bdc689b378, it seems that JSHint is not managed via Grunt anymore. 

However, `newer:jshint:node` is still called when a file changes for Express stuff, causing an error: 

```
Running "newer:jshint:node" (newer) task
Warning: Cannot read property 'files' of undefined
```

I removed the task. I think we can get rid of `grunt-newer` as well. 

Also, I added the files in `backend/**/*.js` to the watch list, so that the server is restarted when there  are changes in the controllers, for example. 