### PR TITLE
Add investigation status

### DIFF
--- a/backend/controllers/situations.js
+++ b/backend/controllers/situations.js
@@ -15,7 +15,7 @@ exports.situation = function(req, res, next, id) {
 
 exports.validateAccess = function(req, res, next) {
     var situation = req.situation;
-    if (req.situation.status === 'test' || !situation.token || req.cookies['situation_' + situation.id] === situation.token) return next();
+    if (req.situation.status === 'test' || req.situation.status === 'investigation' || !situation.token || req.cookies['situation_' + situation.id] === situation.token) return next();
     res.status(403).send({ error: 'You do not have access to this situation.' });
 };
 

--- a/backend/models/situation.js
+++ b/backend/models/situation.js
@@ -94,7 +94,7 @@ var situation = {
     individus: [individuDef],
     menage: menageDef,
     modifiedFrom: String,
-    status: { type: String, default: 'new' },
+    status: { type: String, default: 'new', enum: ['new', 'test', 'investigation'] },
     token: String,
     version: Number,
 };


### PR DESCRIPTION
Les situations sont privées par défaut mais pour celles de tests sont publiques.

Pour faciliter l'investigation d'écarts signalés, les situations peuvent être modifiées pour être visible temporairement en utilisant le `status` `investigation`.