### PR TITLE
Lien "En savoir plus" sur la home

### DIFF
--- a/app/views/partials/homepage.html
+++ b/app/views/partials/homepage.html
@@ -22,7 +22,10 @@
           <div class="col-md-10">
             <dl ng-repeat="droit in provider.prestations">
               <dt>{{ droit.label }}</dt>
-              <dd ng-bind-html="droit.description"></dd>
+              <dd>
+                <div ng-bind-html="droit.description"></div>
+                <a ng-if="droit.link" href="{{ droit.link }}" target="_blank" rel="noopener">En savoir plus <i class="fa fa-external-link" aria-hidden="true"></i></a>
+              </dd>
             </dl>
           </div>
         </div>
@@ -38,8 +41,10 @@
           <div class="col-md-10">
             <dl ng-repeat="droit in provider.prestations">
               <dt>{{ droit.label }}</dt>
-              <dd ng-bind-html="droit.description"></dd>
-              <dd><a href="{{ droit.link }}" target="_blank" rel="noopener">En savoir plus <i class="fa fa-external-link" aria-hidden="true"></i></a></dd>
+              <dd>
+                <div ng-bind-html="droit.description"></div>
+                <a ng-if="droit.link" href="{{ droit.link }}" target="_blank" rel="noopener">En savoir plus <i class="fa fa-external-link" aria-hidden="true"></i></a>
+              </dd>
             </dl>
           </div>
         </div>

--- a/app/views/partials/homepage.html
+++ b/app/views/partials/homepage.html
@@ -39,6 +39,7 @@
             <dl ng-repeat="droit in provider.prestations">
               <dt>{{ droit.label }}</dt>
               <dd ng-bind-html="droit.description"></dd>
+              <dd><a href="{{ droit.link }}" target="_blank" rel="noopener">En savoir plus</a></dd>
             </dl>
           </div>
         </div>

--- a/app/views/partials/homepage.html
+++ b/app/views/partials/homepage.html
@@ -39,7 +39,7 @@
             <dl ng-repeat="droit in provider.prestations">
               <dt>{{ droit.label }}</dt>
               <dd ng-bind-html="droit.description"></dd>
-              <dd><a href="{{ droit.link }}" target="_blank" rel="noopener">En savoir plus</a></dd>
+              <dd><a href="{{ droit.link }}" target="_blank" rel="noopener">En savoir plus <i class="fa fa-external-link" aria-hidden="true"></i></a></dd>
             </dl>
           </div>
         </div>


### PR DESCRIPTION
Suite à une remarque sur Twitter, ajout de liens d'informations sur les différentes aides dès la page d'accueil (lien de la conversation : https://twitter.com/Laribode/status/1017343877982883840 ).

Implémentation assez naïve à refactoriser :)