### PR TITLE
Ajoute un bouton pour télécharger la simulation en PDF

### DIFF
--- a/app/js/controllers/foyer.js
+++ b/app/js/controllers/foyer.js
@@ -81,4 +81,47 @@ angular.module('ddsApp').controller('FoyerCtrl', function($scope, $state, $state
         $scope.$broadcast('patrimoineCaptured');
         $state.go('foyer.resultat');
     });
+
+    $scope.downloadAsPdf = function() {
+
+        var baseURL = window.location.protocol
+            + '//' + window.location.hostname
+            + (window.location.port ? (':' + window.location.port) : '');
+
+        var documentElement = document.documentElement.cloneNode(true);
+
+        var body = documentElement.querySelector('body');
+        var scripts = documentElement.querySelectorAll('body > script');
+
+        // Remove Piwik script to avoid CORS errors with PhantomJS
+        var scriptsToFilter = _.filter(scripts, function(script) {
+            if (script.innerHTML.match(/piwik/gm)) {
+                return true;
+            }
+
+            return script.src.match(/piwik/g);
+        });
+        _.forEach(scriptsToFilter, function(script) {
+            body.removeChild(script);
+        });
+
+        // Convert some links to absolute to have a correct rendering
+
+        var stylesheets = documentElement.querySelectorAll('link');
+        _.forEach(stylesheets, function (stylesheet) {
+            stylesheet.setAttribute('href', baseURL + stylesheet.getAttribute('href'));
+        });
+        var images = documentElement.querySelectorAll('img');
+        _.forEach(images, function (image) {
+            image.setAttribute('src', baseURL + image.getAttribute('src'));
+        });
+
+        var base64 = window.btoa(unescape(encodeURIComponent(documentElement.innerHTML)));
+
+        $scope.base64 = base64;
+
+        setTimeout(function() {
+            document.getElementById("download").submit();
+        }, 2000);
+    };
 });

--- a/app/views/partials/foyer/layout.html
+++ b/app/views/partials/foyer/layout.html
@@ -10,6 +10,13 @@
       <div ui-view="recap_situation" class="recap-situation well whiteframe-z1">
         <p class="text-center"><i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Chargement en cours…</p>
       </div>
+      <form method="post" id="download" ng-hide="! situation._id" class="hidden-xs">
+        <input type="hidden" name="basename" ng-value="situation._id">
+        <input type="hidden" name="base64" ng-value="base64">
+        <button type="submit" class="btn btn-default btn-block" ng-click="downloadAsPdf()">
+          <i class="fa fa-file-pdf-o"></i>  Télécharger ma simulation
+        </button>
+      </form>
     </aside>
   </div>
 </div>

--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -1,5 +1,5 @@
 <ui-view>
-<h1><span ng-dblclick="showRedirection = ! showRedirection">Résultats de votre simulation</span><span id="result-datetime"> du{{ situation.dateDeValeur | date : 'medium' }}</span>
+<h1><span ng-dblclick="showRedirection = ! showRedirection">Résultats de votre simulation</span><span id="result-datetime"> du {{ situation.dateDeValeur | date : 'medium' }}</span>
   <small
     ng-if="showRedirection">
     Redirections&nbsp;:

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -3,6 +3,12 @@ FROM node:6.14-alpine
 RUN apk update \
     && apk add --no-cache git
 
+RUN set -ex \
+  && apk add --no-cache --virtual .build-deps ca-certificates openssl bzip2 \
+  && wget -qO- "https://github.com/dustinblackman/phantomized/releases/download/2.1.1/dockerized-phantomjs.tar.gz" | tar xz -C / \
+  && npm install -g phantomjs \
+  && apk del .build-deps
+
 WORKDIR /srv/app
 
 COPY package.json /srv/app

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express": "~4.15.0",
     "font-awesome": "^4.7.0",
     "frozen-moment": "^0.4.0",
+    "html-pdf": "^2.2.0",
     "js-yaml": "^3.8.4",
     "jsonwebtoken": "^8.3.0",
     "kerberos": "0.0.23",


### PR DESCRIPTION
Le fichier PDF est généré côté serveur et se télécharge directement. 
La technique utilisée est de transformer le code HTML de la page de résultat pour générer le PDF, afin de ne pas avoir à maintenir deux choses différentes. 

La feuille de style utilisée est la même que lors d'une impression, avec un rendu légèrement différent. 

Nécessite betagouv/mes-aides-ops#83

![download_pdf](https://user-images.githubusercontent.com/1162230/46397738-4adab580-c6f3-11e8-8bf7-efae6fc7fc71.gif)
