### PR TITLE
Remove Object.assign in front code

### DIFF
--- a/app/js/controllers/foyer/suggestion.js
+++ b/app/js/controllers/foyer/suggestion.js
@@ -99,7 +99,7 @@ angular.module('ddsApp').controller('SuggestionCtrl', function($scope, $http,dro
         var extension = extensions[0];
 
         $scope.submitting = true;
-        var testMetadata = Object.assign({ extension: extension }, generateState($scope.test));
+        var testMetadata = _.assign({ extension: extension }, generateState($scope.test));
 
         $http.post('api/situations/' + $scope.situation._id + '/openfisca-test', testMetadata)
             .then(function(result) {

--- a/app/js/controllers/homepage.js
+++ b/app/js/controllers/homepage.js
@@ -3,7 +3,7 @@
 angular.module('ddsApp').controller('HomepageCtrl', function($scope, $state, $sessionStorage, droitsDescription, $timeout, ABTestingService, phishingExpressions) {
     [ 'prestationsNationales', 'partenairesLocaux' ].forEach(function(type) {
         var providersWithoutPrivatePrestations = _.mapValues(droitsDescription[type], function(provider) {
-            provider = Object.assign({}, provider);
+            provider = _.assign({}, provider);
             provider.prestations = _.reduce(provider.prestations, function(prestations, prestation, name) {
                 if (! prestation.private) {
                     prestations[name] = prestation;


### PR DESCRIPTION
* Compatibility issue with IE11


Rely on https://lodash.com/docs/4.17.10#assign instead of Object.assign (missing in IE11)