### PR TITLE
Prevent duplicates in injected aids

### DIFF
--- a/app/js/services/resultatService.js
+++ b/app/js/services/resultatService.js
@@ -35,44 +35,6 @@ angular.module('ddsApp').service('ResultatService', function($http, droitsDescri
         }
     }
 
-    function computeEligibleAides(situation, computedRessources, period, customizationId, aidesProvider, injectedAides, isEligible, aide, aideId) {
-
-        if (_.some(situation.individus, function(individu) { return wasInjected(aideId, individu); })) {
-            injectedAides.push(aide);
-            return;  // the aides were declared, do not re-compute the results
-        }
-
-        var value = valueAt(aideId + '_non_calculable', computedRessources, period);
-
-        if ((! value) || value === 'calculable') {
-            value = round(valueAt(aideId, computedRessources, period), aide);
-        }
-
-        if (isEligible) {
-            if (! value) return;
-
-            return _.assign({},
-                aide,
-                {
-                    montant: value,
-                    provider: aidesProvider,
-                },
-                customizationId && aide.customization && aide.customization[customizationId]
-            );
-        } else {
-            if (value) return;
-
-            return _.assign({},
-                aide,
-                {
-                    montant: 0,
-                    provider: aidesProvider,
-                },
-                customizationId && aide.customization && aide.customization[customizationId]
-            );
-        }
-    }
-
     function computeAides(situation, openfiscaResponse) {
         var period = moment(situation.dateDeValeur).format('YYYY-MM');
         var customizationId = CustomizationService.determineCustomizationId(openfiscaResponse, period);
@@ -80,36 +42,39 @@ angular.module('ddsApp').service('ResultatService', function($http, droitsDescri
         var computedRessources = normalizeOpenfiscaRessources(openfiscaResponse);
 
         var result = {
-            eligibleAides: undefined,
-            nonEligibleAides: undefined,
+            eligibleAides: {},
+            nonEligibleAides: {},
             injectedAides: [], // declared by the user
         };
 
-        result.eligibleAides = _.mapValues(droitsDescription, function(aidesProviders) {
-            return _.mapValues(aidesProviders, function(aidesProvider) {
-                var callback = computeEligibleAides.bind(null, situation, computedRessources, period, customizationId, aidesProvider, result.injectedAides, true);
-                var eligibleAides = _.mapValues(aidesProvider.prestations, callback);
+        _.mapValues(droitsDescription, function(aidesProviders, aidesLevel) {
+            result.eligibleAides[aidesLevel] = {};
+            result.nonEligibleAides[aidesLevel] = {};
 
-                return _.assign({}, aidesProvider, { prestations: _.pickBy(eligibleAides) });
+            _.mapValues(aidesProviders, function(aidesProvider) {
+                _.forEach(aidesProvider.prestations, function(aide, aideId) {
+                    if (_.some(situation.individus, function(individu) { return wasInjected(aideId, individu); })) {
+                        return result.injectedAides.push(aide);
+                    }
+
+                    var value = valueAt(aideId + '_non_calculable', computedRessources, period);
+
+                    if ((! value) || value === 'calculable') {
+                        value = round(valueAt(aideId, computedRessources, period), aide);
+                    }
+
+                    var dest = (value) ? result.eligibleAides[aidesLevel] : result.nonEligibleAides[aidesLevel];
+                    dest[aideId] = _.assign({},
+                        aide,
+                        {
+                            montant: value,
+                            provider: aidesProvider,
+                        },
+                        customizationId && aide.customization && aide.customization[customizationId]
+                    );
+                });
             });
         });
-
-        result.nonEligibleAides = _.mapValues(droitsDescription, function(aidesProviders) {
-            return _.mapValues(aidesProviders, function(aidesProvider) {
-                var callback = computeEligibleAides.bind(null, situation, computedRessources, period, customizationId, aidesProvider, result.injectedAides, false);
-                var eligibleAides = _.mapValues(aidesProvider.prestations, callback);
-
-                return _.assign({}, aidesProvider, { prestations: _.pickBy(eligibleAides) });
-            });
-        });
-
-        result.eligibleAides.prestationsNationales = _.reduce(result.eligibleAides.prestationsNationales, function(aides, aidesProvider) {
-            return _.assign(aides, aidesProvider.prestations);  // flatten all national prestations
-        }, {});
-
-        result.nonEligibleAides.prestationsNationales = _.reduce(result.nonEligibleAides.prestationsNationales, function(aides, aidesProvider) {
-            return _.assign(aides, aidesProvider.prestations);  // flatten all national prestations
-        }, {});
 
         result.eligibleAides.partenairesLocaux = _.pickBy(result.eligibleAides.partenairesLocaux, function(aidesProvider) {
             return _.keys(aidesProvider.prestations).length;  // exclude partenaires with no eligible prestations

--- a/test/spec/services/ressourceService.js
+++ b/test/spec/services/ressourceService.js
@@ -11,7 +11,7 @@ describe('RessourceService', function () {
             service = RessourceService;
         });
         individu = {};
-        dateDeValeur = Date();
+        dateDeValeur = moment();
     });
 
     describe('getPeriodKeysForCurrentYear', function() {

--- a/test/spec/services/resultatService.js
+++ b/test/spec/services/resultatService.js
@@ -32,6 +32,9 @@ describe('ResultatService', function () {
                 _: {
                     rsa_non_calculable: {
                         '2014-11': 'error'
+                    },
+                    paris_logement_familles: {
+                        '2014-11': 10
                     }
                 }
             },
@@ -66,6 +69,10 @@ describe('ResultatService', function () {
             expect(droits.droitsInjectes).toContain(DROITS_DESCRIPTION.prestationsNationales.caf.prestations.aide_logement);
             expect(droits.droitsInjectes).toContain(DROITS_DESCRIPTION.prestationsNationales.caf.prestations.ppa);
         });
+
+        it('should not have injected droits duplicates', function() {
+            expect(droits.droitsInjectes.filter(function(d) { return d.label == "Allocation aux adultes handicapés"; }).length).toEqual(1);
+        });
     });
 
     describe('_computeAides of numeric value', function() {
@@ -77,6 +84,10 @@ describe('ResultatService', function () {
             expect(droits.droitsEligibles.prestationsNationales.acs).toBeTruthy();
             expect(droits.droitsEligibles.prestationsNationales.acs.montant).toEqual(100);
             expect(droits.droitsEligibles.prestationsNationales.acs.provider.label).toEqual('Assurance maladie');
+
+            expect(droits.droitsEligibles.partenairesLocaux[0].label).toEqual('Ville de Paris');
+            expect(droits.droitsEligibles.partenairesLocaux[0].prestations.paris_logement_familles).toBeTruthy();
+            expect(droits.droitsEligibles.partenairesLocaux[0].prestations.paris_logement_familles.montant).toEqual(10);
         });
     });
 
@@ -108,7 +119,7 @@ describe('ResultatService', function () {
         });
 
         it('should exclude local partenaire without prestation', function() {
-            expect(droits.droitsEligibles.partenairesLocaux.paris).toBeFalsy();
+            expect(droits.droitsEligibles.partenairesLocaux.filter(function(p) { return p.label == "Rennes Métropole"; }).length).toBeFalsy();
         });
     });
 });

--- a/test/spec/services/resultatService.js
+++ b/test/spec/services/resultatService.js
@@ -88,6 +88,10 @@ describe('ResultatService', function () {
             expect(droits.droitsEligibles.partenairesLocaux[0].label).toEqual('Ville de Paris');
             expect(droits.droitsEligibles.partenairesLocaux[0].prestations.paris_logement_familles).toBeTruthy();
             expect(droits.droitsEligibles.partenairesLocaux[0].prestations.paris_logement_familles.montant).toEqual(10);
+
+            expect(droits.droitsNonEligibles.prestationsNationales.cmu_c).toBeTruthy();
+            expect(droits.droitsNonEligibles.prestationsNationales.cmu_c.montant).toBeFalsy();
+            expect(droits.droitsNonEligibles.prestationsNationales.cmu_c.provider.label).toEqual('Assurance maladie');
         });
     });
 


### PR DESCRIPTION
The current OpenFisca payload processing leads to duplicates in injected aids.

With this PR I push forward the previous implementation of ResultatService and add test to ensure, that local aids and visible and that no duplicates are generated.

This is a naive implementation but the result page is currently unusable when injected aids are shown.