### PR TITLE
Add tests for YAML test generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,9 +204,8 @@ workflows:
             - test_karma
       - test_openfisca_test_generation:
           requires:
+            - install
             - install_openfisca
-            - test_mocha
-            - test_karma
       - deploy:
           requires:
             - test_selenium_chrome

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,16 @@ jobs:
       - run:
           name: Watai family suite
           command: node_modules/.bin/watai test/integration/family-suite  --config '{"driverCapabilities":{"browserName":"chrome","version":"latest"}}'
+  test_openfisca_test_generation:
+    <<: *defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/mes-aides-ui
+      - *install_pip_and_pipenv
+      - run:
+          name: Check OpenFisca test generation
+          command: npm run test:openfisca
   deploy:
     machine:
       enabled: true
@@ -192,9 +202,15 @@ workflows:
             - install_openfisca
             - test_mocha
             - test_karma
+      - test_openfisca_test_generation:
+          requires:
+            - install_openfisca
+            - test_mocha
+            - test_karma
       - deploy:
           requires:
             - test_selenium_chrome
+            - test_openfisca_test_generation
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ jobs:
       - *install_pip_and_pipenv
       - run:
           name: Check OpenFisca test generation
-          command: npm run test:openfisca
+          command: pipenv run npm run test:openfisca
   deploy:
     machine:
       enabled: true

--- a/backend/lib/openfisca/test.js
+++ b/backend/lib/openfisca/test.js
@@ -53,6 +53,9 @@ var EXTENSION_VARIABLES = {
     'openfisca-rennesmetropole': {
         individus: [ 'rennes_metropole_transport' ],
     },
+    'openfisca-bacASable': {
+        familles: [ 'alfortville_noel_enfants']
+    }
 };
 
 function prepareTestSituationForSpecificExtension(situation, extension) {
@@ -109,3 +112,5 @@ exports.generateTest = function generateYAMLTest(details, situation) {
 exports.generateYAMLTest = function generateYAMLTest(details, situation) {
     return toYAML(exports.generateTest(details, situation));
 };
+
+exports.EXTENSION_VARIABLES = EXTENSION_VARIABLES;

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "build": "NODE_ENV=production webpack --mode=production",
     "build:dev": "webpack --mode=development",
     "lint": "eslint .",
-    "test:openfisca": "INTEGRATION_TEST=1 mocha test/backend/openfisca/test.js --timeout 10000",
+    "test:openfisca": "mocha test/backend/openfisca/test.js --timeout 10000",
     "test:mocha": "mocha --recursive test/backend",
     "test:karma": "grunt test",
     "test": "npm run test:mocha && npm run test:karma",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "raven-js": "^3.26.3",
     "request-promise": "^4.2.2",
     "serve-favicon": "^2.4.0",
-    "sgmap-mes-aides-api": "sgmap/mes-aides-api#v12.0.0"
+    "sgmap-mes-aides-api": "sgmap/mes-aides-api#v12.0.0",
+    "tmp": "0.0.33"
   },
   "repository": {
     "type": "git",
@@ -118,6 +119,7 @@
     "build": "NODE_ENV=production webpack --mode=production",
     "build:dev": "webpack --mode=development",
     "lint": "eslint .",
+    "test:openfisca": "INTEGRATION_TEST=1 mocha test/backend/openfisca/test.js --timeout 10000",
     "test:mocha": "mocha --recursive test/backend",
     "test:karma": "grunt test",
     "test": "npm run test:mocha && npm run test:karma",

--- a/test/backend/openfisca/test.js
+++ b/test/backend/openfisca/test.js
@@ -1,4 +1,5 @@
 var expect = require('expect');
+var _ = require('lodash');
 var fs = require('fs');
 var subject = require('../../../backend/lib/openfisca/test');
 var tmp = require('tmp');
@@ -92,10 +93,13 @@ describe('openfisca generateYAMLTest', function() {
 
             Object.keys(subject.EXTENSION_VARIABLES).forEach(function(extensionName) {
                 it('passes OpenFisca test with ' + extensionName  + ' extension', function(done) {
-                    var details = Object.assign({}, details, { output_variables: { rsa: 545.48 }});
-                    var yaml = subject.generateYAMLTest(details, situation);
+                    var details = Object.assign({ extension: extensionName }, details, { output_variables: { rsa: 545.48 }});
+                    var yamlContent = subject.generateYAMLTest(details, situation);
 
-                    runOpenFiscaTest(yaml, extensionName.replace('-', '_'), done);
+                    var variableListRegex = _.values(subject.EXTENSION_VARIABLES[extensionName]).map(function(variableList) { return variableList.join('|'); }).join('|');
+                    expect(yamlContent).toMatch(new RegExp(variableListRegex));
+
+                    runOpenFiscaTest(yamlContent, extensionName.replace('-', '_'), done);
                 });
             });
         });

--- a/test/backend/openfisca/test.js
+++ b/test/backend/openfisca/test.js
@@ -30,7 +30,6 @@ var situation = {
     },
 };
 
-
 describe('openfisca generateTest', function() {
     var result = subject.generateTest(details, situation);
 
@@ -51,7 +50,7 @@ function run_cmd(cmd, args, callback ) {
     child.on('error', function(err) { callback(err); });
 }
 
-function runOpenFiscaTest(yaml, extension, done) {
+function runAndCheckOpenFiscaTest(yaml, extension, done) {
     if (! done) {
         done = extension;
         extension = undefined;
@@ -82,13 +81,13 @@ describe('openfisca generateYAMLTest', function() {
         expect(result).toInclude('valueOne: 1');
     });
 
-    if (process.env.INTEGRATION_TEST) {
+    if (process.env.VIRTUAL_ENV) {
         describe('generates processable YAML files', function() {
             it('passes OpenFisca test without extension', function(done) {
                 var details = Object.assign({}, details, { output_variables: { rsa: 545.48 }});
                 var yaml = subject.generateYAMLTest(details, situation);
 
-                runOpenFiscaTest(yaml, done);
+                runAndCheckOpenFiscaTest(yaml, done);
             });
 
             Object.keys(subject.EXTENSION_VARIABLES).forEach(function(extensionName) {
@@ -99,7 +98,7 @@ describe('openfisca generateYAMLTest', function() {
                     var variableListRegex = _.values(subject.EXTENSION_VARIABLES[extensionName]).map(function(variableList) { return variableList.join('|'); }).join('|');
                     expect(yamlContent).toMatch(new RegExp(variableListRegex));
 
-                    runOpenFiscaTest(yamlContent, extensionName.replace('-', '_'), done);
+                    runAndCheckOpenFiscaTest(yamlContent, extensionName.replace('-', '_'), done);
                 });
             });
         });


### PR DESCRIPTION
We want to move away from [Ludwig v1](https://github.com/betagouv/ludwig-ui) and use [Ludwig v2](https://github.com/betagouv/ludwig).

Ludwig 1 was two things at the same time:
- an expectation editor,
- a test directory and
- a test runner

With Ludwig 1 it was easy to generate tests but they were hard to use for developers (tests are in a database). 

Ludwig 2 is a way to link applications to their repository and their test base.
The Ludwig 2 v0 (🙃) is a single endpoint to POST file test content to be added to the underlying repository.

This PR ensure that generated YAML are valid OpenFisca tests.