### PR TITLE
Improve YAML representation

### DIFF
--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -115,8 +115,12 @@ angular.module('ddsCommon').factory('SituationService', function($http, $session
             situation.individus.forEach(function(individu) {
                 individu.date_naissance = individu.date_naissance.format('YYYY-MM-DD');
                 delete individu.hasRessources;
+
+                if (individu.dateDernierContratTravail) {
+                    individu.dateDernierContratTravail = individu.dateDernierContratTravail.format('YYYY-MM-DD');
+                }
             });
-            return jsyaml.dump(_.omit(situation, '__v'));
+            return jsyaml.dump(_.omit(situation, ['__v', 'modifiedFrom', 'status', 'token', 'version']));
         },
 
         /**


### PR DESCRIPTION
Previously, too many attributes were displayed and `dateDernierContratTravail` is ugly (a moment instead of a YYY-MM-DDD date).

![capture d ecran de 2018-11-05 13-35-00](https://user-images.githubusercontent.com/1410356/47998448-a4257280-e0ff-11e8-9b9a-7d718b240f09.png)
