### PR TITLE
Utilise require() pour charger les templates Angular

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1,5 +1,10 @@
 'use strict';
 
+// Use Webpack's require.context to manage dynamic requires for templates
+// The templates will be cached when the application is booted
+// https://webpack.js.org/guides/dependency-management/#require-context
+var template = require.context('../views', true, /(partials|content-pages)\/.*\.html$/);
+
 var ddsApp = angular.module('ddsApp', ['ui.router', 'ngAnimate', 'ddsCommon', 'ngSanitize', 'angulartics', 'angulartics.piwik']);
 
 ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $uiViewScrollProvider) {
@@ -306,7 +311,7 @@ ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $u
         });
 });
 
-ddsApp.run(function($rootScope, $state, $stateParams, $window, $anchorScroll, $timeout) {
+ddsApp.run(function($rootScope, $state, $stateParams, $window, $anchorScroll, $templateCache, $timeout) {
     $rootScope.$state = $state;
     $rootScope.$stateParams = $stateParams;
 
@@ -333,6 +338,15 @@ ddsApp.run(function($rootScope, $state, $stateParams, $window, $anchorScroll, $t
                 title.focus();
             }
         });
+    });
+
+    // Preload templates in cache
+    // We use the keys() function of the context module API
+    // to iterate over the templates, and we store them in Angular's template cache.
+    // This means Angular won't try to load the template via AJAX
+    _.forEach(template.keys(), function(path) {
+        var cacheKey = path.replace('./', '/');
+        $templateCache.put(cacheKey, template(path));
     });
 
     $rootScope.$on('$locationChangeSuccess', function(event, current) {

--- a/app/js/directives/breadcrumb.js
+++ b/app/js/directives/breadcrumb.js
@@ -17,7 +17,7 @@ function matchStep(state, step) {
 angular.module('ddsApp').directive('breadcrumb', function($rootScope) {
     return {
         restrict: 'E',
-        templateUrl: 'partials/breadcrumb.html',
+        templateUrl: '/partials/breadcrumb.html',
         controller: function($scope, $state) {
 
             // @see https://ui-router.github.io/guide/ng1/migrate-to-1_0#state-change-events

--- a/app/js/directives/captureContinuationRessource.js
+++ b/app/js/directives/captureContinuationRessource.js
@@ -22,7 +22,7 @@ angular.module('ddsApp').directive('captureContinuation', function(MonthService)
     return {
         restrict: 'E',
         replace: true,
-        templateUrl: 'partials/foyer/capture-continuation-ressource.html',
+        templateUrl: '/partials/foyer/capture-continuation-ressource.html',
         scope: {
             dateDeValeur: '=',
             individu: '=',

--- a/app/js/directives/captureMontantRessource.js
+++ b/app/js/directives/captureMontantRessource.js
@@ -5,7 +5,7 @@ angular.module('ddsApp').directive('captureMontantRessource', function(MonthServ
     return {
         restrict: 'E',
         replace: true,
-        templateUrl: 'partials/foyer/capture-montant-ressource.html',
+        templateUrl: '/partials/foyer/capture-montant-ressource.html',
         scope: {
             individu: '=',
             ressourceType: '=',

--- a/app/js/directives/droitsEligiblesList.js
+++ b/app/js/directives/droitsEligiblesList.js
@@ -23,10 +23,10 @@ var controllerOptions = function(templateUrl) {
 };
 
 angular.module('ddsApp')
-    .directive('droitEligiblesList', controllerOptions('partials/droits-eligibles-list.html'));
+    .directive('droitEligiblesList', controllerOptions('/partials/droits-eligibles-list.html'));
 
 angular.module('ddsApp')
-    .directive('droitNonEligiblesList', controllerOptions('partials/droits-non-eligibles-list.html'));
+    .directive('droitNonEligiblesList', controllerOptions('/partials/droits-non-eligibles-list.html'));
 
 angular.module('ddsApp').controller('droitsEligiblesListCtrl', function($scope, TrampolineService) {
     $scope.isNumber = _.isNumber;

--- a/app/js/directives/droitsList.js
+++ b/app/js/directives/droitsList.js
@@ -3,7 +3,7 @@
 angular.module('ddsApp').directive('droitsList', function() {
     return {
         restrict: 'E',
-        templateUrl: 'partials/droits-list.html',
+        templateUrl: '/partials/droits-list.html',
         scope: {
             droits: '='
         }

--- a/app/js/directives/etablissementsList.js
+++ b/app/js/directives/etablissementsList.js
@@ -3,7 +3,7 @@
 angular.module('ddsApp').directive('etablissementsList', function() {
     return {
         restrict: 'E',
-        templateUrl: 'partials/etablissements-list.html',
+        templateUrl: '/partials/etablissements-list.html',
         scope: {
             codeInsee: '=',
             codePostal: '='

--- a/app/js/directives/individuBlock.js
+++ b/app/js/directives/individuBlock.js
@@ -3,7 +3,7 @@
 angular.module('ddsCommon').directive('individuBlock', function(IndividuService) {
     return {
         restrict: 'E',
-        templateUrl: 'partials/individu-block.html',
+        templateUrl: '/partials/individu-block.html',
         scope: {
             individu: '='
         },

--- a/app/js/directives/yesNoQuestion.js
+++ b/app/js/directives/yesNoQuestion.js
@@ -4,7 +4,7 @@ angular.module('ddsApp').directive('yesNoQuestion', function($parse) {
     return {
         restrict: 'E',
         transclude: true,
-        templateUrl: 'partials/foyer/yes-no-question.html',
+        templateUrl: '/partials/foyer/yes-no-question.html',
         scope: true,
         controller: 'yesNoQuestionCtrl',
         link: function ($scope, $element, $attributes) {

--- a/app/js/directives/ym2RessourcesCallToAction.js
+++ b/app/js/directives/ym2RessourcesCallToAction.js
@@ -3,7 +3,7 @@
 angular.module('ddsApp').directive('ym2RessourcesCallToAction', function() {
     return {
         restrict: 'E',
-        templateUrl: 'partials/ym2-ressources-call-to-action.html',
+        templateUrl: '/partials/ym2-ressources-call-to-action.html',
         scope: true
     };
 });

--- a/app/views/partials/foyer/ressources/montants.html
+++ b/app/views/partials/foyer/ressources/montants.html
@@ -8,7 +8,7 @@
       <div class="clearfix"></div>
       <div class="content">
         <div>
-          <div ng-include="'partials/foyer/ressources/detail-montants.html'"></div>
+          <div ng-include="'/partials/foyer/ressources/detail-montants.html'"></div>
         </div>
       </div>
       <hr>

--- a/docker/nginx/snippets/mes-aides-static.conf
+++ b/docker/nginx/snippets/mes-aides-static.conf
@@ -2,10 +2,6 @@ location /favicon.ico {
   rewrite ^.*$ /img/favicon/favicon.ico;
 }
 
-location ~ ^/(partials|content-pages) {
-  try_files /dist/views$uri =404;
-}
-
 location ~ ^/(documents|fonts|img|js|styles) {
   access_log off;
   try_files /dist$uri =404;

--- a/index.js
+++ b/index.js
@@ -63,13 +63,6 @@ module.exports = function(app) {
     app.use('/documents', express.static(path.join(__dirname, 'dist/documents'), CACHE.FIVE_MINUTES));
     app.use(              express.static(path.join(__dirname, 'dist'),           CACHE.NONE));
 
-    app.use('/recap-situation/partials', express.static(path.join(viewsDirectory + '/partials')));
-    app.use('/partials', express.static(viewsDirectory + '/partials'));
-    app.use('/content-pages', express.static(viewsDirectory + '/content-pages'));
-    app.use('/partials', function(req, res) {
-        return res.sendStatus(404);
-    });
-
     app.use(bodyParser.urlencoded({ limit: '1024kb' }));
 
     // Route to download a PDF

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,6 +3,30 @@
 // Karma configuration
 // http://karma-runner.github.io/0.10/config/configuration-file.html
 
+// https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+var isCircleCI = process.env.CIRCLECI && process.env.CIRCLECI === 'true';
+var useProductionAssets = isCircleCI || process.env.NODE_ENV === 'production';
+
+var files = [];
+if (useProductionAssets) {
+    files = [
+        // On CircleCI, we test against production build
+        'dist/js/vendor.*.js',
+        'dist/js/stats.*.js',
+        'dist/js/scripts.recapSituation.*.js',
+        'dist/js/scripts.*.js',
+    ];
+} else {
+    // TODO Make sure Webpack DevServer is running (?)
+    files = [
+        // Serve files from Webpack DevServer
+        'http://localhost:8080/js/vendor.js',
+        'http://localhost:8080/js/stats.js',
+        'http://localhost:8080/js/scripts.recapSituation.js',
+        'http://localhost:8080/js/scripts.js',
+    ];
+}
+
 module.exports = function(config) {
   config.set({
     // base path, that will be used to resolve files and exclude
@@ -12,16 +36,12 @@ module.exports = function(config) {
     frameworks: ['jasmine'],
 
     // list of files / patterns to load in the browser
-    files: [
-      'dist/js/vendor.*.js',
-      'dist/js/stats.*.js',
-      'dist/js/scripts.recapSituation.*.js',
-      'dist/js/scripts.*.js',
+    files: files.concat([
       'node_modules/angular-mocks/angular-mocks.js',
       // FIXME Can't find variable: moment
       'node_modules/moment/moment.js',
       'test/spec/**/*.js',
-    ],
+    ]),
 
     // list of files / patterns to exclude
     exclude: [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,22 +20,12 @@ module.exports = function(config) {
       'node_modules/angular-mocks/angular-mocks.js',
       // FIXME Can't find variable: moment
       'node_modules/moment/moment.js',
-      'dist/views/**/*.html',
       'test/spec/**/*.js',
     ],
 
     // list of files / patterns to exclude
     exclude: [
     ],
-
-    preprocessors: {
-      '**/*.html': ['ng-html2js']
-    },
-
-    ngHtml2JsPreprocessor: {
-      stripPrefix: 'dist/views',
-      moduleName: 'templates'
-    },
 
     // web server port
     port: 8002,

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "jasmine-core": "*",
     "karma": "^1.0.0",
     "karma-jasmine": "^1.0.2",
-    "karma-ng-html2js-preprocessor": "^1.0.0",
     "karma-ng-scenario": "^1.0.0",
     "karma-phantomjs-launcher": "^1.0.1",
     "karma-requirejs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "grunt-nodemon": "~0.4.0",
     "grunt-open": "^0.2.3",
     "grunt-webpack": "^3.1.3",
+    "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
     "jasmine-core": "*",
     "karma": "^1.0.0",

--- a/test/spec/directives/date.js
+++ b/test/spec/directives/date.js
@@ -4,7 +4,6 @@ describe('directive dds-date', function() {
     var $scope, form;
 
     beforeEach(module('ddsApp'));
-    beforeEach(module('templates'));
 
     beforeEach(inject(function($compile, $rootScope) {
         $scope = $rootScope;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,11 +60,21 @@ var config = {
                 use: [
                     'file-loader?name=img/[name].[ext]',
                 ]
+            },
+            {
+                test: /\.html$/,
+                exclude: /(front|embed)\.html$/,
+                use: [{
+                    loader: 'html-loader',
+                    options: {
+                        minimize: true,
+                    }
+                }],
             }
         ]
     },
     devServer: {
-        contentBase: './app',
+        contentBase: path.join(__dirname, 'dist'),
     },
     plugins: [
         new CopyWebpackPlugin([

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,7 +80,6 @@ var config = {
         new CopyWebpackPlugin([
             { from: 'app/documents', to: 'documents/' },
             { from: 'app/img', to: 'img/' },
-            { from: 'app/views', to: 'views/', ignore: [ 'front.html', 'embed.html' ] },
         ]),
         // Avoid bundling all Moment locales
         // @see https://github.com/moment/moment/issues/2517


### PR DESCRIPTION
Donc on a une régression par rapport à avant : en dev, les templates ne sont pas mis à jour. 

Quelques explications ci-dessous. 

Quand on lance `npm run dev`, ça lance : 
- 1/ un build Webpack "simple", en mode dev (pas d'optimisations)
- 2/ Webpack Dev Server sur le port `8080`

Ensuite, les assets sont servis depuis `http://localhost:8080`, ce qui permet d'avoir la dernière version des assets compilés en mémoire par Webpack DevServer. 

Or, les fichiers templates `*.html` sont eux aussi servis par Webpack DevServer, et ils ne sont donc pas copiés dans `/dist` à chaque changement !

Dans les fichiers Angular, on fait ça en général : 

```javascript
templateUrl: '/partials/foyer/individu-form.html'
```

Ça veut dire que le fichier `*.html` sera chargé en AJAX, mais depuis `http://localhost:9000` !
Il faudrait pouvoir préfixer toutes ces URLs par `http://localhost:8080` en dev, mais ça paraît galère avec Angular UI Router. 

---

J'ai opté pour une autre technique : utiliser `require()` pour inclure le fichier de template. 
D'après [cet article](https://medium.com/@frosty/angularjs-template-vs-templateurl-cdde055b7907) c'est mieux, et du coup on utilise un peu plus les possibilités offertes par Webpack. 

Dans une première version, j'avais remplacé les appels à : 

```javascript
templateUrl: '/partials/foyer/individu-form.html'
```

par : 

```javascript
template: require('../views/partials/foyer/individu-form.html')
```

Mais il restait un problème parce qu'on utilise `ng-include`. 
J'ai donc changé de technique : j'utilise [`require.context`](https://webpack.js.org/guides/dependency-management/#require-context) et [`$templateCache`](https://docs.angularjs.org/api/ng/service/$templateCache) pour précharger les templates. 
Ainsi, les appels à une URL continuent de fonctionner comme avant, sans appel AJAX 🙂 

---

Attention : ça signifie dans tous les cas que les templates sont inclus en inline dans le bundle JavaScript. Ça augmente un peu la taille du bundle (244K vs 117K actuellement). 

> tl;dr: bigger js files, but no requests at runtime which means instant loading of components

Je pense que ça vaut largement le coup de les mettre en inline, étant donné que ça représente une taille assez négligeable, une fois gzippé. 

C'est aussi plus simple : avant, il fallait des règles dans le backend pour servir le path `/partials` (qui n'existe pas réellement). Avec `require()`, c'est un _vrai_ chemin relatif. 

```javascript
app.use('/recap-situation/partials', express.static(path.join(viewsDirectory + '/partials')));
app.use('/partials', express.static(viewsDirectory + '/partials'));
```

En mettant les templates en inline, l'application devient encore plus auto-suffisante, et indépendante de l'environnement serveur 🙂

**TODO**
- [x] Gérer l'utilisation de `ng-include`
- [x] Ne plus copier les partials dans `/dist`
- [x] Ne plus charger les vues dans Karma
- [x] Supprimer les règles de réécriture dans Express/Nginx