### PR TITLE
Only remove _id from situation sent to server

### DIFF
--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -97,12 +97,10 @@ angular.module('ddsCommon').factory('SituationService', function($http, $session
         save: function(situation) {
             if (situation._id) {
                 situation.modifiedFrom = situation._id;
-                delete situation._id;
             }
-
             cleanSituation(situation);
 
-            return $http.post('/api/situations/', situation)
+            return $http.post('/api/situations/', _.omit(situation, '_id'))
                 .then(function(result) { return result.data; })
                 .then(saveLocal);
         },


### PR DESCRIPTION
* _id is kept in the local object
* In the suggestion view, on refresh situation were _id less.