### PR TITLE
Add production domain to whitelistUrls.

### DIFF
--- a/app/sentry.js
+++ b/app/sentry.js
@@ -2,6 +2,9 @@ var Raven = require('raven-js');
 
 Raven
     .config('https://fde1d4c9741e4ef3a3416e4e88b61392@sentry.data.gouv.fr/17', {
+        whitelistUrls: [
+            /mes-aides\.gouv\.fr/
+        ],
         ignoreUrls: [
             /^file:\/\//i
         ]


### PR DESCRIPTION
The goal is to [reduce noise](https://blog.sentry.io/2017/03/27/tips-for-reducing-javascript-error-noise#whitelist-your-urls) by filtering out errors triggered by browsers plugins, for example.