### PR TITLE
Rely on fixed ludwig-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jsonwebtoken": "^8.3.0",
     "kerberos": "0.0.23",
     "lodash": "^4.17.4",
-    "ludwig-api": "^1.2.0",
+    "ludwig-api": "betagouv/ludwig-api#v1.3.0",
     "ludwig-ui": "^1.5.4",
     "mingo": "^2.2.4",
     "moment": "^2.8.3",


### PR DESCRIPTION
I don't think removing bluebird is the way to go. I have done a hotfix in Ludwig API.

closes #927  and #888

`end()` is not mandatory cf.
- https://mongoosejs.com/docs/4.x/docs/api.html#promise_Promise-end
- https://github.com/aheckmann/mpromise#end