### PR TITLE
Précisions aides non calculées

### DIFF
--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -111,7 +111,7 @@
     </div>
 
     <div>
-      <h4 ng-show="! (droitsInjectes | isEmpty)">Aides que vous percevez déjà aujourd'hui, et dont nous n'avons pas recalculé le montant</h4>
+      <h4 ng-show="! (droitsInjectes | isEmpty)">Vous avez indiqué ces aides au cours la simulation et elles n'ont pas été recalculées</h4>
       <droits-list droits="droitsInjectes"></droits-list>
     </div>
 


### PR DESCRIPTION
La dénomination "Aides que vous percevez déjà aujourd'hui, et dont nous n'avons pas recalculé le montant" a déjà induit en erreur à ma connaissance au moins deux personnes en fin de simulation.

Lorsqu'on déclare par exemple une aide sur sa simulation, comme la prime d'activité, mais qu'on ne la reçoit plus aujourd'hui, ce message est tout de même affiché.

Le message "Vous avez indiqué ces aides au cours la simulation et elles n'ont pas été recalculées" est plus neutre.