### PR TITLE
Upgrade OpenFisca Core and France

### DIFF
--- a/backend/lib/openfisca/mapping/index.js
+++ b/backend/lib/openfisca/mapping/index.js
@@ -109,6 +109,12 @@ exports.buildOpenFiscaRequest = function(sourceSituation) {
         aide_logement_date_pret_conventionne: {}
     }, situation.menage);
 
+    // Use heuristics to pass functional tests
+    // Complexity may be added in the future in the application (new questions to ask)
+    // So far, due to a bug or some ambiguity
+    // cf. https://github.com/openfisca/openfisca-france/pull/1233
+    // logement_conventionne needs to be true when the loan in fully paid
+    // to avoid a benefit from appearing
     menage.logement_conventionne[periods.thisMonth] = menage.statut_occupation_logement == 'primo_accedant' && menage.loyer == 0;
     menage.aide_logement_date_pret_conventionne[periods.thisMonth] = '2017-12-31';
 

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,7 +1,7 @@
 gunicorn>=19.1.1
 Openfisca-France==32.1.0
 git+https://github.com/openfisca/openfisca-core.git@simplify-cycle-detection-24.11.0#egg=openfisca-core [web-api]
-git+https://github.com/betagouv/openfisca-bacASable.git#egg=openfisca-BacASable
-git+https://github.com/betagouv/openfisca-paris.git#egg=openfisca-paris
-git+https://github.com/betagouv/openfisca-brestmetropole.git#egg=openfisca-BrestMetropole
-git+https://github.com/betagouv/openfisca-rennesmetropole.git#egg=openfisca-RennesMetropole
+git+https://github.com/betagouv/openfisca-bacASable.git@9e4c107#egg=openfisca-BacASable
+git+https://github.com/betagouv/openfisca-paris.git@63c5c2e#egg=openfisca-paris
+git+https://github.com/betagouv/openfisca-brestmetropole.git@63af363#egg=openfisca-BrestMetropole
+git+https://github.com/betagouv/openfisca-rennesmetropole.git@ef2b4b3#egg=openfisca-RennesMetropole

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,6 +1,6 @@
 gunicorn>=19.1.1
-Openfisca-France==29.2.0
-git+https://github.com/openfisca/openfisca-core.git@simplify-cycle-detection#egg=openfisca-core [web-api]
+Openfisca-France==32.1.0
+git+https://github.com/openfisca/openfisca-core.git@simplify-cycle-detection-24.11.0#egg=openfisca-core [web-api]
 git+https://github.com/betagouv/openfisca-bacASable.git#egg=openfisca-BacASable
 git+https://github.com/betagouv/openfisca-paris.git#egg=openfisca-paris
 git+https://github.com/betagouv/openfisca-brestmetropole.git#egg=openfisca-BrestMetropole


### PR DESCRIPTION
Cette PR est une première mise à jour d'OpenFisca.

| Mes Aides | Core  | France |
|-|-|-|
|Production|24.10.0 + cycle| 29.2.0|
|This PR|24.11.0 + cycle| 32.1.0|
|Another PR|25.2.2 + cycle?| 32.3.0|

La 25.0.0 sur Core impacte les fichiers de tests de toutes les extensions, c'est pour ça que je préfère faire les modifs en plusieurs temps.

Il semble y avoir une erreur dans le calcul des aides au logement cf. https://github.com/openfisca/openfisca-france/pull/1233). Dans l'attente de l'intégration d'un fix dans OpenFisca-France, un hack est inclu dans cette PR.