### PR TITLE
Ajout un tooltip pour préciser les revenus avant retenue à la source

### DIFF
--- a/app/js/constants/ressources.js
+++ b/app/js/constants/ressources.js
@@ -65,7 +65,8 @@
             id: 'chomage_net',
             label: 'Allocations chômage (ARE)',
             category: 'allocations',
-            interuptionQuestionLabel: 'des allocations chômage, un salaire ou des indemnités de la sécurité sociale'
+            interuptionQuestionLabel: 'des allocations chômage, un salaire ou des indemnités de la sécurité sociale',
+            hint: 'Entrez le montant avant la retenue à la source'
         },
         {
             id: 'allocation_securisation_professionnelle',
@@ -192,7 +193,8 @@
             id: 'indemnites_journalieres_maladie',
             label: 'Indemnités maladie',
             category: 'indemnites',
-            interuptionQuestionLabel: 'des indemnités de la sécurité sociale, un salaire ou des allocations chômage'
+            interuptionQuestionLabel: 'des indemnités de la sécurité sociale, un salaire ou des allocations chômage',
+            hint: 'Entrez le montant avant la retenue à la source'
         },
         {
             id: 'indemnites_journalieres_maladie_professionnelle',
@@ -224,6 +226,7 @@
             category: 'revenusActivite',
             prefix: 'des',
             revenuExceptionnel: true,
+            hint: 'Entrez le montant avant la retenue à la source'
         },
         {
             id: 'dedommagement_victime_amiante',
@@ -253,7 +256,8 @@
             id: 'retraite_nette',
             label: 'Retraite (y compris reversion), rente',
             category: 'pensions',
-            prefix: 'une'
+            prefix: 'une',
+            hint: 'Entrez le montant avant la retenue à la source'
         },
         {
             id: 'retraite_combattant',

--- a/app/js/constants/ressources.js
+++ b/app/js/constants/ressources.js
@@ -38,7 +38,8 @@
             label: 'Salaire (hors primes)',
             category: 'revenusActivite',
             interuptionQuestionLabel: 'un salaire, des allocations chômage, ou des indemnités de la sécurité sociale',
-            positionInList: '1'
+            positionInList: '1',
+            hint: 'Entrez le montant avant la retenue à la source'
         },
         {
             id: 'primes_salaires_net',

--- a/app/views/partials/foyer/capture-montant-ressource.html
+++ b/app/views/partials/foyer/capture-montant-ressource.html
@@ -21,6 +21,11 @@
               ng-model="locals.monthlyValue"
               select-on-focus
               zero-to-empty
+              uib-tooltip="{{ ressourceType.hint || '' }}"
+              tooltip-trigger="'mouseenter'"
+              tooltip-placement="top"
+              tooltip-enable="!! ressourceType.hint"
+              tooltip-append-to-body="true"
               >
             <div class="input-group-addon">€</div>
           </div>
@@ -69,6 +74,11 @@
                 zero-to-empty
                 ng-model="ressource[month.id]"
                 aria-describedby="help-{{ ressourceType.id }}-month_{{ $index }}"
+                uib-tooltip="{{ ressourceType.hint || '' }}"
+                tooltip-trigger="'mouseenter'"
+                tooltip-placement="top"
+                tooltip-enable="!! ressourceType.hint"
+                tooltip-append-to-body="true"
                 >
               <span class="input-group-addon">€</span>
             </div>
@@ -94,6 +104,11 @@
                 zero-to-empty
                 ng-model="locals.annualValue"
                 aria-describedby="help-{{ ressourceType.id }}-year"
+                uib-tooltip="{{ ressourceType.hint || '' }}"
+                tooltip-trigger="'mouseenter'"
+                tooltip-placement="top"
+                tooltip-enable="!! ressourceType.hint"
+                tooltip-append-to-body="true"
                 >
               <span class="input-group-addon">€</span>
             </div>

--- a/app/views/partials/foyer/capture-montant-ressource.html
+++ b/app/views/partials/foyer/capture-montant-ressource.html
@@ -22,7 +22,7 @@
               select-on-focus
               zero-to-empty
               uib-tooltip="{{ ressourceType.hint || '' }}"
-              tooltip-trigger="'mouseenter'"
+              tooltip-trigger="'focus'"
               tooltip-placement="top"
               tooltip-enable="!! ressourceType.hint"
               tooltip-append-to-body="true"
@@ -75,7 +75,7 @@
                 ng-model="ressource[month.id]"
                 aria-describedby="help-{{ ressourceType.id }}-month_{{ $index }}"
                 uib-tooltip="{{ ressourceType.hint || '' }}"
-                tooltip-trigger="'mouseenter'"
+                tooltip-trigger="'focus'"
                 tooltip-placement="top"
                 tooltip-enable="!! ressourceType.hint"
                 tooltip-append-to-body="true"
@@ -105,7 +105,7 @@
                 ng-model="locals.annualValue"
                 aria-describedby="help-{{ ressourceType.id }}-year"
                 uib-tooltip="{{ ressourceType.hint || '' }}"
-                tooltip-trigger="'mouseenter'"
+                tooltip-trigger="'focus'"
                 tooltip-placement="top"
                 tooltip-enable="!! ressourceType.hint"
                 tooltip-append-to-body="true"


### PR DESCRIPTION
Fixes #993 

<img width="855" alt="capture d ecran 2018-12-19 a 12 15 02" src="https://user-images.githubusercontent.com/1162230/50217937-8bf57400-038a-11e9-888b-6592b254f7c5.png">
