### PR TITLE
Make CI builds more reliable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,8 @@ jobs:
           keys:
             - v12.1.3-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
       - run:
-          name: NPM install
-          command: npm install
+          name: Install packages from package-lock.json
+          command: npm ci
       - run:
           name: Install SauceLabs
           command: npm install saucelabs


### PR DESCRIPTION
`npm install` n'installe pas à partir du `package-lock.json` mais à partir de `package.json` et de nouvelles versions des dépendances peuvent être utilisées. C'est risqué.

J'ai eu des soucis d'installation dans la revue/modification sur #990 et j'ai découvert ce problème.

Une PR similaire sera faite sur mes-aides-ops pour garantir les déploiements de la production.
cf. https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable