### PR TITLE
Update OpenFisca-Core to use custom version

### DIFF
--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,6 +1,6 @@
 gunicorn>=19.1.1
 Openfisca-France==32.3.0
-git+https://github.com/openfisca/openfisca-core.git@simplify-cycle-detection-25.2.2#egg=openfisca-core [web-api]
+git+https://github.com/openfisca/openfisca-core.git@mitigate-cycle-and-simplify-cycle-detection-25.2.2#egg=openfisca-core [web-api]
 git+https://github.com/betagouv/openfisca-bacASable.git#egg=openfisca-BacASable
 git+https://github.com/betagouv/openfisca-paris.git@01743ba#egg=openfisca-paris
 git+https://github.com/betagouv/openfisca-brestmetropole.git@0341592#egg=openfisca-BrestMetropole


### PR DESCRIPTION
L'API Web de OpenFisca évalue les expressions « comme elles arrivent », c'est à dire en fonction de leur position dans le payload JSON.

La version de Core utilisée dans cette PR, trie par période (2016 avant 2017) et cela de façon stable, c'est à dire sans changer l'ordre des calculs de même priorité.

Cette PR ne devrait pas avoir d'impact en soi mais elle contribue à #994 sans faire une _Big Bang_ PR.