### PR TITLE
Corrige le texte pour les pensions alimentaires versées

### DIFF
--- a/app/js/directives/captureMontantRessource.js
+++ b/app/js/directives/captureMontantRessource.js
@@ -1,6 +1,26 @@
 'use strict';
 
 angular.module('ddsApp').directive('captureMontantRessource', function(MonthService) {
+    function getInitialLabel (individu, ressource, debutAnneeGlissante) {
+        var subject = {
+            'demandeur': 'Vous',
+            'conjoint': 'Votre conjoint·e',
+            'enfant': individu.firstName,
+        }[individu.role];
+        var verbForms = {
+            pensions_alimentaires_versees_individu: {
+                demandeur: 'versez',
+                default: 'verse'
+            },
+            default: {
+                demandeur: 'recevez',
+                default: 'reçoit'
+            }
+        };
+        var verbForm = verbForms[ressource.id] || verbForms.default;
+        var verb = verbForm[individu.role] || verbForm.default;
+        return [subject, verb, 'tous les mois depuis', debutAnneeGlissante].join(' ');
+    }
 
     return {
         restrict: 'E',
@@ -23,6 +43,8 @@ angular.module('ddsApp').directive('captureMontantRessource', function(MonthServ
             var lastMonth = recentMonths[0];
             var currentMonth = recentMonths[1];
             var isoMonths = last12Months;
+
+            scope.regularResourcePrompt = getInitialLabel(scope.individu, scope.ressourceType, scope.debutAnneeGlissante);
 
             scope.isNumber = angular.isNumber;
             scope.ressource = scope.individu[scope.ressourceType.id];

--- a/app/views/partials/foyer/capture-montant-ressource.html
+++ b/app/views/partials/foyer/capture-montant-ressource.html
@@ -8,7 +8,7 @@
         ng-class="{ 'has-error': form.submitted && form[ ressourceType.id + '-monthly-value'].$invalid }"
         >
         <label class="col-sm-5 control-label" for="{{ ressourceType.id }}-monthly-value">
-          Vous recevez tous les mois depuis {{ debutAnneeGlissante }}&nbsp;:
+          {{ regularResourcePrompt }}&nbsp;:
         </label>
         <div class="col-sm-4">
           <div class="input-group">


### PR DESCRIPTION
Sur l'écran des pensions alimentaires **versées**, il est écrit :
> Vous recevez tous les mois depuis décembre 2017 :
Or il faudrait écrire
> Vous versez tous les mois depuis décembre 2017 : 


De plus, pas de distinction n'est faite entre le demandeur et son conjoint. 

Cette PR corrige ces deux problèmes.

Avant
![capture d ecran de 2018-12-31 14-45-45](https://user-images.githubusercontent.com/1410356/50561435-0e771f80-0d0b-11e9-8d90-34006ef3643b.png)

Après
![capture d ecran de 2018-12-31 14-46-26](https://user-images.githubusercontent.com/1410356/50561436-0e771f80-0d0b-11e9-86f6-dce560382229.png)

