### PR TITLE
Met à jour OpenFiscaFrance avec une estimation de la PPA

### DIFF
--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,5 +1,5 @@
 gunicorn>=19.1.1
-Openfisca-France==32.3.0
+git+https://github.com/openfisca/openfisca-france.git@reval-ppa#egg=Openfisca-France
 git+https://github.com/openfisca/openfisca-core.git@mitigate-cycle-and-simplify-cycle-detection-25.2.2#egg=openfisca-core [web-api]
 git+https://github.com/betagouv/openfisca-bacASable.git#egg=openfisca-BacASable
 git+https://github.com/betagouv/openfisca-paris.git@01743ba#egg=openfisca-paris


### PR DESCRIPTION
Il n'y a pas encore de texte officiel qui explicite comme la revalorisation exceptionnelle va être faite.
Cela dit avec les éléments disponibles on peut en avoir une idée grossière.


En gros, j'ai fait une estimation au rabais :
- de 0 à 0.5 SMIC : 0% de la bonification
- de 0.5 à 1 SMIC : ça varie de 0% à 100% de la bonification
 - de 1 à 1.5 SMIC : ça varie de 100% à 0% de la bonification.

Le montant de la bonification est de [78€ puis 85 €](https://github.com/openfisca/openfisca-france/blob/reval-ppa/openfisca_france/parameters/prestations/minima_sociaux/ppa/seconde_bonification/montant_maximal.yaml). C'est une estimation. Il faudra faire des comparaisons avec le simulateur de caf.fr le 2 janvier.

J'ai créé [un test dans une branche d'OpenFica France](https://github.com/openfisca/openfisca-france/blob/reval-ppa/tests/formulas/ppa/ppa_urgence_economique_et_sociale.yaml).


Je pense que c'est une bonne première estimation. Ça a de la valeur de mettre ça en production dès maintenant pour faire de la comm'.

Au pire, ça crée de la mauvaise pub et on revient en arrière.