### PR TITLE
Calcule les prestations sur 4 mois (le courant et les 3 précédents)

### DIFF
--- a/backend/lib/openfisca/mapping/common.js
+++ b/backend/lib/openfisca/mapping/common.js
@@ -28,6 +28,10 @@ exports.getPeriods = function (dateDeValeur) {
         '1MonthsAgo': dateDeValeur.clone().subtract(1, 'months').format('YYYY-MM'),
         '2MonthsAgo': dateDeValeur.clone().subtract(2, 'months').format('YYYY-MM'),
         '3MonthsAgo': dateDeValeur.clone().subtract(3, 'months').format('YYYY-MM'),
+        // 3-element array of the latest 3 months
+        last3Months: _.map(_.range(1, 3 + 1), function(monthIndex) {
+            return dateDeValeur.clone().subtract(monthIndex, 'months').format('YYYY-MM');
+        }),
         // 12-element array of the latest 12 months
         last12Months: _.map(_.range(1, 12 + 1), function(monthIndex) {
             return dateDeValeur.clone().subtract(monthIndex, 'months').format('YYYY-MM');

--- a/backend/lib/openfisca/mapping/index.js
+++ b/backend/lib/openfisca/mapping/index.js
@@ -36,10 +36,9 @@ function allocateIndividualsToEntities(situation) {
     menage.enfants = enfantIds;
 }
 
-var notInjectedAids = ['aah'];
 function setNonInjectedPrestations(testCase, periods, value) {
-    var prestationsFinancieres = _.pickBy(common.requestedVariables, function(definition, definitionName) {
-        return ((! definition.type) || definition.type === 'float') && notInjectedAids.indexOf(definitionName) == -1;
+    var prestationsFinancieres = _.pickBy(common.requestedVariables, function(definition) {
+        return ((! definition.type) || definition.type === 'float');
     });
 
     _.forEach(prestationsFinancieres, function(definition, prestationName) {

--- a/backend/lib/openfisca/mapping/index.js
+++ b/backend/lib/openfisca/mapping/index.js
@@ -140,9 +140,9 @@ exports.buildOpenFiscaRequest = function(sourceSituation) {
     propertyMove.movePropertyValuesToGroupEntity(testCase);
 
     var periods = common.getPeriods(situation.dateDeValeur);
-    setNonInjectedPrestations(testCase, periods.last12Months, 0);
+    setNonInjectedPrestations(testCase, _.difference(periods.last12Months, periods.last3Months), 0);
     last3MonthsDuplication(testCase, situation.dateDeValeur);
-    giveValueToRequestedVariables(testCase, periods.thisMonth, null);
+    giveValueToRequestedVariables(testCase, _.concat(periods.last3Months, periods.thisMonth), null);
 
     return applyHeuristicsAndFix(testCase, sourceSituation.dateDeValeur);
 };


### PR DESCRIPTION
Fixes #994.

Un travail de fiabilisation de la prime d'activité a été fait sur OpenFisca. Les prestations étaient regardées au mois de calcul à la place des mois du trimestre de référence.

| |Oct-18|Nov-18|Déc-18|Janv-19|
-|-|-|--|-
|Avant||||AF|
|Maintenant|AF|AF|AF||

Cela correspond à la législation mais nécessite des évolutions sur Mes Aides pour afficher des montants plus pertinents.
Jusqu'à présent, sur Mes Aides, les prestations calculées sont mises à zéro sur les 12 derniers mois. C'est tout à fait sensé car nous n'avons pas les données pour évaluer de façon pertinente le droit au RSA il y a douze mois. En même temps cela gonfle les prestations qui reposent sur d'autres prestations (ACS, CMU-C, RSA et PPA, AL qui reposent sur par exemple AL, ASF, AAH, ASS).

Avec cette PR les prestations calculées par le simulateur ne sont mises à 0 que pour les 9 premiers mois de l'année glissante (ie. de Janvier 18 à Septembre 18 mais pas en Oct, Nov et Décembre 18). Sur ces 3 mois, les prestations sont évaluées et potentiellement intégrée à l'évaluation des prestations du mois courant (Janvier 19).


Cette PR va
- Corriger les montants de prestations suite à la prise en compte des prestations déjà perçues mais non indiquées dans Mes Aides (RSA, PPA principalement).
- Augmenter les AL pour les personnes ne bénéficiant pas encore du RSA mais qui y sont éligibles.
