### PR TITLE
Améliore le gestionnaire de personnalisation des liens

### DIFF
--- a/app/js/services/customizationService.js
+++ b/app/js/services/customizationService.js
@@ -4,7 +4,9 @@ angular.module('ddsCommon').factory('CustomizationService', function(lyonMetropo
 
     function determineCustomizationId(testCase, currentPeriod) {
         if (testCase.menages &&
-            testCase.menages._) {
+            testCase.menages._ &&
+            testCase.menages._.depcom &&
+            testCase.menages._.depcom[currentPeriod]) {
             if (testCase.menages._.depcom[currentPeriod].match(/^05/))
                 return 'D05-HAUTES_ALPES';
             if (testCase.menages._.depcom[currentPeriod].match(/^06/))


### PR DESCRIPTION
* Évite une erreur JS quand le ménage n'est pas bien défini.
* Une validation plus complète devrait être faite avant d'essayer d'évaluer des droits.