### PR TITLE
Corrige l'utilisation de Sentry dans Angular

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1,11 +1,20 @@
 'use strict';
 
+var Raven = require('raven-js');
+var ngRaven = require('raven-js/plugins/angular').moduleName;
+
 // Use Webpack's require.context to manage dynamic requires for templates
 // The templates will be cached when the application is booted
 // https://webpack.js.org/guides/dependency-management/#require-context
 var template = require.context('../views', true, /(partials|content-pages)\/.*\.html$/);
 
-var ddsApp = angular.module('ddsApp', ['ui.router', 'ngAnimate', 'ddsCommon', 'ngSanitize', 'angulartics', 'angulartics.piwik']);
+var requires = ['ui.router', 'ngAnimate', 'ddsCommon', 'ngSanitize', 'angulartics', 'angulartics.piwik'];
+
+if (Raven.isSetup()) {
+    requires.push(ngRaven);
+}
+
+var ddsApp = angular.module('ddsApp', requires);
 
 ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $uiViewScrollProvider) {
     moment.locale('fr');

--- a/app/scripts.js
+++ b/app/scripts.js
@@ -32,6 +32,10 @@ require('./styles/recap-situation.css');
 require('./styles/droits-eligibles-list.css');
 require('./styles/breadcrumb.css');
 
+if (process.env.NODE_ENV === 'production') {
+    require('./sentry.js');
+}
+
 require('./js/common.js');
 require('./js/app.js');
 

--- a/app/scripts.recapSituation.js
+++ b/app/scripts.recapSituation.js
@@ -15,6 +15,10 @@ require('angular-i18n/angular-locale_fr');
 
 require('./styles/front.scss');
 
+if (process.env.NODE_ENV === 'production') {
+    require('./sentry.js');
+}
+
 require('./js/embed.js');
 require('./js/common.js');
 

--- a/app/views/front.html
+++ b/app/views/front.html
@@ -104,9 +104,6 @@
     <% } else { %>
     <script src="<%= htmlWebpackPlugin.files.chunks['vendor'].entry %>"></script>
     <script src="<%= htmlWebpackPlugin.files.chunks['stats'].entry %>"></script>
-    {{#sentry}}
-    <script src="<%= htmlWebpackPlugin.files.chunks['sentry'].entry %>"></script>
-    {{/sentry}}
     <script src="<%= htmlWebpackPlugin.files.chunks['scripts'].entry %>"></script>
     <% } %>
 

--- a/index.js
+++ b/index.js
@@ -89,7 +89,6 @@ module.exports = function(app) {
     app.route('/*').get(function(req, res) {
         res.render('front', {
             prestationsCount: prestationsNationalesCount + partenairesLocauxCount,
-            sentry: env === 'production'
         });
     });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,9 +9,6 @@ var merge = require('webpack-merge');
 
 var config = {
     entry: {
-        sentry: [
-            './app/sentry.js'
-        ],
         scripts: [
             './app/scripts.js'
         ],


### PR DESCRIPTION
Il manquait `ngRaven` dans l'appel à `angular.module`.

Du coup, j'ai simplifié pour ne pas avoir à créer d'asset `sentry.js`, tout est packagé directement dans le bundle de production. 