### PR TITLE
Fixe les erreurs JavaScript

### DIFF
--- a/app/js/controllers/foyer/conjoint.js
+++ b/app/js/controllers/foyer/conjoint.js
@@ -5,7 +5,7 @@ angular.module('ddsApp').controller('FoyerConjointCtrl', function($scope, $state
     var hasChildren = SituationService.hasEnfant($scope.situation);
     $scope.famille = $scope.situation.famille;
 
-    var isFirstView = demandeur.statut_marital == undefined;
+    var isFirstView = demandeur.statut_marital === undefined;
     $scope.locals = {
         isInCouple : isFirstView ? undefined : Boolean(SituationService.getConjoint($scope.situation)),
     };

--- a/app/js/controllers/foyer/ressources/individu.js
+++ b/app/js/controllers/foyer/ressources/individu.js
@@ -1,9 +1,10 @@
 'use strict';
 
-angular.module('ddsApp').controller('FoyerRessourcesIndividuCtrl', function($scope, $stateParams, MonthService, IndividuService, RessourceService) {
+angular.module('ddsApp').controller('FoyerRessourcesIndividuCtrl', function($scope, $stateParams, MonthService, IndividuService, RessourceService, SituationService) {
     $scope.months = MonthService.getMonths($scope.situation.dateDeValeur);
     var individuIndex = parseInt($stateParams.individu);
-    $scope.individu = $scope.sortedIndividus[individuIndex];
+    var sortedIndividus = SituationService.getIndividusSortedParentsFirst($scope.situation);
+    $scope.individu = sortedIndividus[individuIndex];
     $scope.selectedRessourceTypes = RessourceService.extractIndividuSelectedRessourceTypes($scope.individu);
     $scope.pageTitle = IndividuService.ressourceHeader($scope.individu);
 });

--- a/app/js/controllers/foyer/ressources/ressources.js
+++ b/app/js/controllers/foyer/ressources/ressources.js
@@ -2,7 +2,7 @@
 
 angular.module('ddsApp').controller('FoyerRessourcesCtrl', function($scope, $state, ressourceTypes, SituationService) {
 
-    $scope.sortedIndividus = SituationService.getIndividusSortedParentsFirst($scope.situation);
+    var sortedIndividus = SituationService.getIndividusSortedParentsFirst($scope.situation);
     var haveEnfantsResourcesBeenDeclared;
 
     $scope.markEnfantsAsDeclared = function() {
@@ -14,7 +14,7 @@ angular.module('ddsApp').controller('FoyerRessourcesCtrl', function($scope, $sta
     $scope.declareNextIndividuResources = function (lastIndividuDeclaredIndex) {
         $scope.$parent.$broadcast('ressourcesUpdated');
         var nextIndividuIndex = lastIndividuDeclaredIndex + 1;
-        var nextIndividu = $scope.sortedIndividus[nextIndividuIndex];
+        var nextIndividu = sortedIndividus[nextIndividuIndex];
         if (! nextIndividu) {
             $state.go('foyer.pensionsAlimentaires');
             return;

--- a/test/spec/controllers/foyer/ressources/individu.js
+++ b/test/spec/controllers/foyer/ressources/individu.js
@@ -6,8 +6,10 @@ describe('Controller: FoyerRessourcesIndividuCtrl', function() {
 
     beforeEach(function() {
         scope = {
-            situation: { dateDeValeur: '2013-04-10' },
-            sortedIndividus: [{ role: 'demandeur' }, { role: 'conjoint' }, { role: 'enfant', firstName: 'Jérome' }]
+            situation: {
+                dateDeValeur: '2013-04-10',
+                individus: [{ role: 'demandeur' }, { role: 'enfant', firstName: 'Jérome' }, { role: 'conjoint' }]
+            }
         };
         module('ddsApp');
         inject(function($controller) {


### PR DESCRIPTION
Il semble y avoir une race condition dans les controllers `ressources.*`

La variable `$scope.sortedIndividus` est vide dans `FoyerRessourcesIndividuCtrl`, alors qu'elle est censée être initialisée dans le controller parent, `FoyerRessourcesCtrl`

https://github.com/betagouv/mes-aides-ui/blob/d023c91b16c35a8f2f2593c76a16f15819251e71/app/js/controllers/foyer/ressources/ressources.js#L3-L7

De ce que je comprends, ce n'est pas très "catholique" de faire ça dans tous les cas, il faut plutôt utiliser [`resolve`](https://github.com/angular-ui/ui-router/wiki#resolve), mais on ne peut pas, car `resolve` ne peut pas lire le `$scope`.

Bref, j'ai tout simplement évité de compter sur cette relation parent/enfant, et j'ai évité de stocker `sortedIndividus` dans `$scope`, puisque ce n'est utilisé dans aucun template. 