### PR TITLE
Limite le besoin du patrimoine aux situations pertinentes

### DIFF
--- a/app/js/constants/droits.js
+++ b/app/js/constants/droits.js
@@ -145,6 +145,7 @@
                             'caf': 'https://www.formulaires.modernisation.gouv.fr/gf/cerfa_15481.do',
                             'msa': 'https://www.formulaires.modernisation.gouv.fr/gf/cerfa_15481.do'
                         },
+                        'isBaseRessourcesPatrimoine': true,
                         'uncomputability': {
                             'tns': {
                                 'reason': {
@@ -191,6 +192,7 @@
                             'msa': 'http://www.msa.fr/lfr/c/bookmarks/open_entry?entryId=98643'
                         },
                         'isBaseRessourcesYearMoins2': true,
+                        'isBaseRessourcesPatrimoine': true,
                         'uncomputability': {
                             'primo_accedant': {
                                 'reason': {

--- a/app/js/controllers/resultat.js
+++ b/app/js/controllers/resultat.js
@@ -69,8 +69,13 @@ angular.module('ddsApp').controller('ResultatCtrl', function($analytics, $http, 
                 $scope.debutPeriode = moment($scope.situation.dateDeValeur).startOf('month').subtract(1, 'years').format('MMMM YYYY');
                 $scope.finPeriode = moment($scope.situation.dateDeValeur).startOf('month').subtract(1, 'months').format('MMMM YYYY');
                 $scope.ressourcesYearMoins2Captured = SituationService.ressourcesYearMoins2Captured($scope.situation);
+
                 $scope.shouldPatrimoineBeCaptured = function() {
-                    return ! angular.isDefined(SituationService.hasPatrimoine($scope.situation));
+                    if ((! $scope.droits) || (! $scope.droits.prestationsNationales)) {
+                        return;
+                    }
+
+                    return _.some($scope.droits.prestationsNationales, 'isBaseRessourcesPatrimoine') && ! angular.isDefined(SituationService.hasPatrimoine($scope.situation));
                 };
             });
     }


### PR DESCRIPTION
La spécification du patrimoine ne vient que _diminuer_ du droit et jamais l'augmenter.

C'est pourquoi, il me parait intéressant de limiter le CTA du patrimoine que dans les situations où des prestations susceptibles de bougées à cause du patrimoine sont affichées.

Cette PR permet de diminuer la taille de celle de la refonte de la page de résultats en apportant des fonctionnalité à la production actuelle.