### PR TITLE
Supprime les appels aux méthodes ayant disparues dans Angular 1.7

### DIFF
--- a/app/js/controllers/resultat.js
+++ b/app/js/controllers/resultat.js
@@ -103,9 +103,9 @@ angular.module('ddsApp').controller('ResultatCtrl', function($analytics, $http, 
         $http.post('api/public/acceptance-tests', {
             expectedResults: expectedResults,
             scenario: { situationId: $scope.situation._id }
-        }).success(function(data) {
+        }).then(function(data) {
             $window.location.href = '/tests/' + data._id + '/edit';
-        }).error(function(data) {
+        }).catch(function(data) {
             $window.alert(data.error.apiError);
         });
     };


### PR DESCRIPTION
Lié à https://code.angularjs.org/1.4.14/docs/api/ng/service/$http#deprecation-notice