### PR TITLE
Ajoute le tag meta "robots"

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -159,6 +159,9 @@ ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $u
         .state('validation', {
             url: '/validation',
             templateUrl: '/partials/validation.html',
+            data: {
+                robots: 'noindex'
+            },
             controller: 'ValidationCtrl'
         })
         .state('foyer', {

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -64,7 +64,8 @@ ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $u
             url: '/ameli',
             templateUrl: '/content-pages/ameli.html',
             data: {
-                pageTitle: 'Bienvenue sur Mes Aides'
+                pageTitle: 'Bienvenue sur Mes Aides',
+                robots: 'noindex'
             }
         })
         .state('ameliorer', {
@@ -116,7 +117,8 @@ ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $u
             url: '/hameconnage',
             templateUrl: '/content-pages/hameconnage.html',
             data: {
-                pageTitle: '⚠️ Hameçonnage ⚠️'
+                pageTitle: '⚠️ Hameçonnage ⚠️',
+                robots: 'noindex'
             },
             controller: function($scope) {
                 $scope.referrer = document.referrer;
@@ -197,6 +199,9 @@ ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $u
                 'individuForm@foyer.conjoint': individuFormView('conjoint')
             },
             resolve: resolveIndividuRole('conjoint'),
+            data: {
+                robots: 'noindex'
+            }
         })
         .state('foyer.enfants', {
             url: '/enfants',
@@ -208,6 +213,9 @@ ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $u
                 'validate@foyer.enfants': {
                     templateUrl: '/partials/foyer/enfants/validate.html',
                 },
+            },
+            data: {
+                robots: 'noindex'
             }
         })
         .state('foyer.enfants.ajouter', {
@@ -244,12 +252,18 @@ ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $u
         .state('foyer.logement', {
             url: '/logement',
             templateUrl: '/partials/foyer/logement.html',
-            controller: 'FoyerLogementCtrl'
+            controller: 'FoyerLogementCtrl',
+            data: {
+                robots: 'noindex'
+            }
         })
         .state('foyer.ressources', {
             url: '/ressources',
             controller: 'FoyerRessourcesCtrl',
-            templateUrl: '/partials/foyer/ressources/layout.html'
+            templateUrl: '/partials/foyer/ressources/layout.html',
+            data: {
+                robots: 'noindex'
+            }
         })
         .state('foyer.ressources.enfants', {
             templateUrl: '/partials/foyer/ressources/enfants.html',
@@ -274,12 +288,18 @@ ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $u
         .state('foyer.pensionsAlimentaires', {
             templateUrl: '/partials/foyer/pensions-alimentaires.html',
             controller: 'FoyerPensionsAlimentairesCtrl',
-            url: '/pensions-alimentaires'
+            url: '/pensions-alimentaires',
+            data: {
+                robots: 'noindex'
+            }
         })
         .state('foyer.resultat', {
             url: '/resultat?situationId',
             templateUrl: '/partials/resultat.html',
-            controller: 'ResultatCtrl'
+            controller: 'ResultatCtrl',
+            data: {
+                robots: 'noindex'
+            }
         }).state('foyer.resultat.suggestion', {
             url: '/suggestion',
             templateUrl: '/partials/suggestion.html',
@@ -303,13 +323,19 @@ ddsApp.config(function($locationProvider, $stateProvider, $urlRouterProvider, $u
         .state('redirection', {
             url: '/redirection?vers',
             templateUrl: '/partials/redirection.html',
-            controller: 'RedirectionCtrl'
+            controller: 'RedirectionCtrl',
+            data: {
+                robots: 'noindex'
+            }
         })
         .state('situation', { // Route used by Ludwig
             url: '/situations/:situationId',
             template: '',
             controller: function(SituationService, $state, $stateParams) {
                 $state.go('foyer.resultat', { situationId: $stateParams.situationId });
+            },
+            data: {
+                robots: 'noindex'
             }
         });
 });
@@ -337,6 +363,24 @@ ddsApp.run(function($rootScope, $state, $stateParams, $window, $analytics, $anch
                 title.focus();
             }
         });
+    });
+
+    // Update <meta name="robots"> in vanilla JavaScript,
+    // because nothing else works
+    $transitions.onSuccess({}, function(transition) {
+
+        var robots = $window.document.querySelector('head meta[name="robots"]');
+        if (! robots) {
+
+            return;
+        }
+
+        var state = transition.to();
+        if (state.data && state.data.robots) {
+            robots.content = state.data.robots;
+        } else {
+            robots.content = 'index,follow';
+        }
     });
 
     // Preload templates in cache

--- a/app/views/front.html
+++ b/app/views/front.html
@@ -10,6 +10,7 @@
 
     <meta property="fb:pages" content="260041744438137">
     <meta name="google-site-verification" content="DJvbR2NnlgepVQJLNyqv45sWwHnz3o7umOuMXfEgNoM" />
+    <meta name="robots" content="index,follow" />
 
     <meta name="viewport" content="initial-scale=1">
 

--- a/robots.txt
+++ b/robots.txt
@@ -12,3 +12,4 @@ Disallow: /redirection
 Disallow: /situations/*
 Disallow: /tests
 Disallow: /tests/*
+Disallow: /validation


### PR DESCRIPTION
Donc on a pas mal de pages indexées malgré le blocage par `robots.txt`

Apparemment, c'est [normal](https://support.google.com/webmasters/answer/7440203#indexed_though_blocked_by_robots_txt), Google indexe les pages avec des liens qui pointent dessus. Pour empêcher l'indexation, il faut utiliser la directive `robots=noindex`.

Google supporte [les tags meta gérés en JavaScript](https://webmasters.googleblog.com/2015/10/deprecating-our-ajax-crawling-scheme.html), donc pas de problème. 

J'ai essayé sans succès d'utiliser `ng-attr-content`, [ngMeta](https://github.com/vinaygopinath/ngMeta) et [ui-router-metatags](https://github.com/tinusn/ui-router-metatags), l'attribut `content` n'est jamais modifié, j'ai donc géré ça en vanilla JavaScript. 
Par défaut, tout est indexable, sauf si c'est spécifié dans le state.

<img width="920" alt="capture d ecran 2019-01-16 a 12 07 51" src="https://user-images.githubusercontent.com/1162230/51245243-62c70400-1987-11e9-8d4a-1968e1225ce6.png">

