### PR TITLE
Rend toute la largeur cliquable pour les ressources

### DIFF
--- a/app/views/partials/foyer/ressources/types.html
+++ b/app/views/partials/foyer/ressources/types.html
@@ -13,12 +13,14 @@
           is-open="status.open"
           ng-init="status.open = shouldInitiallyOpen(category)">
           <uib-accordion-heading>
-            <i class="fa"
-              aria-hidden="true"
-              role="presentation"
-              ng-class="{'fa-chevron-down': status.open, 'fa-chevron-right': !status.open}">
-            </i>
-            {{ category.label }}
+            <div>
+              <i class="fa"
+                aria-hidden="true"
+                role="presentation"
+                ng-class="{'fa-chevron-down': status.open, 'fa-chevron-right': !status.open}">
+              </i>
+              {{ category.label }}
+            </div>
           </uib-accordion-heading>
           <div class="button-grid">
             <label ng-repeat="ressourceType in ressourceTypesByCategories[category.id]| orderBy:['positionInList','label']"


### PR DESCRIPTION
Aujourd'hui en production, il faut cliquer sur le texte de la section, un clic sur le bandeau ne fonctionne pas.

![capture d ecran de 2019-01-16 16-41-50](https://user-images.githubusercontent.com/1410356/51260027-a7659600-19ad-11e9-9a17-65950a03cd71.png)

Cette PR corrige ce problème.
