### PR TITLE
Répare des régressions de l'interface

### DIFF
--- a/app/views/partials/foyer/recap-situation.html
+++ b/app/views/partials/foyer/recap-situation.html
@@ -78,7 +78,7 @@
       class="ressources-accordion">
       <div uib-accordion-group
         ng-repeat="ym2IndividuRecap in ressourcesYearMoins2"
-        class="ressources-recap"
+        class="ressources-recap panel panel-default"
         heading="{{ ym2IndividuRecap.label }}"
         is-open="ym2IndividuRecap.isOpen">
         <div class="row" ng-repeat="ressource in ym2IndividuRecap.ressources">
@@ -104,7 +104,7 @@
       <div uib-accordion-group
         ng-if="patrimoine.length"
         heading="Patrimoine"
-        class="ressources-recap"
+        class="ressources-recap panel panel-default"
         is-open="revenu.isOpen">
         <div ng-repeat="value in patrimoine">
           {{ value.label }}&nbsp;: {{ value.montant | currency }}

--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -40,7 +40,10 @@
     </p>
     <div class="frame-resultats">
       <droit-eligibles-list
-        droits="droits.prestationsNationales">
+        droits="droits.prestationsNationales"
+        ressources-year-moins-2-captured="ressourcesYearMoins2Captured"
+        year-moins-2="yearMoins2"
+      >
       </droit-eligibles-list>
       <ym2-ressources-call-to-action ng-hide="ressourcesYearMoins2Captured"></ym2-ressources-call-to-action>
 


### PR DESCRIPTION
* L'avertissement pour la saisie des ressources de l'année fiscale de référence de disparaissaient pas à cause de https://github.com/betagouv/mes-aides-ui/pull/1055/files#diff-439d28d21f87cd9eda392ce9b500c1c2R30 et 
https://github.com/betagouv/mes-aides-ui/pull/1055/files#diff-9e9cc87424300731ec4e7469df72cb80R76

* Les ressources YM2 et le patrimoine étaient cassés dans le récapitulatif à cause de la montée de version je pense.