### PR TITLE
 Supprime des cookies de situations anciennes

### DIFF
--- a/backend/routes/situations.js
+++ b/backend/routes/situations.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var cookieParser = require('cookie-parser');
 var cors = require('cors');
 
 var situations = require('../controllers/situations');
@@ -8,6 +9,7 @@ module.exports = function(api) {
     api.route('/situations').post(situations.create);
 
     var route = new express.Router({ mergeParams: true });
+    route.use(cookieParser());
     route.use(situations.validateAccess);
 
     route.get('/', situations.show);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cleave.js": "~0.7.15",
     "codes-postaux": "etalab/codes-postaux#003ea027941e7a40c6094c7a02e7299d37619712",
     "consolidate": "^0.15.1",
+    "cookie-parser": "^1.4.3",
     "cors": "^2.8.4",
     "currencyformatter.js": "^2.1.0",
     "d3": "4.11.0",


### PR DESCRIPTION
Mes Aides est aujourd'hui dysfonctionnel pour les personnes faisant un grand nombre de simulations.

En effet, pour chaque situation, un cookie est ajouté à la session. Dans certains cas, il peut y avoir plus de 30 cookies et cela ne plaît pas du tout au serveur.

Cette PR vient corriger le problème en supprimant les cookies de simulations anciennes en conservant 10 cookies.