### PR TITLE
Mise à jour / TPN et Chèque Energie

### DIFF
--- a/app/views/content-pages/liens-utiles.html
+++ b/app/views/content-pages/liens-utiles.html
@@ -12,30 +12,30 @@
 
   <h2 id="energie">Vous n'arrivez plus à payer vos dépenses d'énergie ou vous souhaitez faire des travaux de rénovation énergétique</h2>
 
-  <p>Le Chèque Énergie remplace les tarifs sociaux de l'énergie depuis janvier 2018. Il peut être utilisé pour toutes les dépenses d'énergie (électricité, gaz, fioul, bois, etc.) et les travaux de rénovation énergétique. Les bénéficiaires des tarifs sociaux 2017 conservent cependant leurs droits associés jusqu’au 30 avril 2018. Le Chèque Énergie est attribué sous conditions de ressources et de composition du foyer. Vous pouvez en savoir plus <a href="https://www.chequeenergie.gouv.fr/>">sur le site internet dédié</a> ou passer la simulation sur Mes Aides pour vérifier votre éligibilité.</p>
+  <p>Depuis janvier 2018, le Chèque Énergie peut être utilisé pour toutes les dépenses d'énergie (électricité, gaz, fioul, bois, etc.) et les travaux de rénovation énergétique. Il est attribué sous conditions de ressources et de composition du foyer. Le Chèque Énergie se base sur les ressources de votre dernière déclaration de revenus et est envoyé au printemps. Vous pouvez en savoir plus <a href="https://www.chequeenergie.gouv.fr/>">sur le site internet dédié</a> ou passer la simulation sur Mes Aides pour vérifier votre éligibilité.</p>
 
   <h2 id="pension-alimentaire">Vous ne recevez pas l’intégralité d’une pension alimentaire attribuée par une décision de justice</h2>
 
   <p>Lorsque le parent qui doit verser une pension alimentaire pour votre ou vos enfant•s ne le fait pas, ne la paye qu'en partie ou irrégulièrement (par exemple un mois sur deux), votre Caf ou MSA peut vous aider à récupérer les sommes qui sont dues. Contactez l’<a href="https://www.pension-alimentaire.caf.fr/">Agence du recouvrement des impayés de pensions alimentaires</a> pour entamer les démarches.</p>
-  
+
   <h2 id="bilan-sante">Vous souhaitez faire le point sur votre santé</h2>
-  
+
   <p>Vous pouvez bénéficier d'un <a href="https://www.service-public.fr/particuliers/vosdroits/F170">examen de prévention en santé</a> (anciennement bilan de santé gratuit), si vous dépendez du régime général de sécurité sociale ou de la Mutualité sociale agricole (MSA). Cet examen est également proposé aux assurés de certains autres régimes. Le bilan peut permettre de dépister des maladies ignorées ou cachées.</p>
 
   <h2 id="mesquestionsdargent">Vous recherchez des conseils financiers</h2>
 
   <p>La Banque de France met à disposition un portail d'information sur les questions liées à l'argent : le portail <a href="https://www.mesquestionsdargent.fr">Mes Questions d’Argent</a>. Ce portail vous oriente vers des informations sélectionnées sur des sites partenaires : conseils pour prendre une décision financière, contacts pour joindre une personne qui répondra à vos besoins…</p>
-  
+
   <h2 id="entreprises">Vous souhaitez obtenir des aides pour votre entreprise</h2>
-  
+
   <p>Pour savoir quelles aides votre entreprise peut obtenir, par exemple lors d'une passation ou bien en cas de difficulté financière, vous pouvez vous rendre sur <a href="http://www.aides-entreprises.fr/">la base de données de référence</a> ouverte à tous. Les CCI de France ont également ouvert <a href="http://les-aides.fr/">un portail répondant à ces questions</a>. </p>
 
   <h2 id="rapatriement">Vous résidez à l'étranger et souhaitez rentrer en France</h2>
-  
+
   <p>Le simulateur <a href="http://retour-en-france.simplicite.fr/">Retour en France</a> vous sera utile. Cet outil a été conçu par les services de l’État pour guider les Français·e·s établi·e·s à l’étranger dans la préparation des démarches administratives liées à leur retour en France. Vous pouvez également vous renseigner sur <a href="https://www.service-public.fr/particuliers/vosdroits/F32823">les démarches et les possibilités</a> qui s’offrent à vous.</p>
   <p>Si vous rencontrez de grandes difficultés, prenez contact avec <a href="http://www.france-horizon.fr/article/que_faire_pour_rentrer_en_france">France Horizon</a>.</p>
- 
- 
+
+
   <h2 id="sos">Votre situation est critique</h2>
 
   <p>Nous avons réuni sur la <a ui-sref="sos">page SOS</a> les premières mesures que vous pouvez prendre afin de faire face à l'urgence de votre situation.</p>


### PR DESCRIPTION
Cette PR clarifie le Chèque Energie en supprimant les anciennes informations sur les tarifs de première nécessité, deprecated depuis avril dernier.