### PR TITLE
Ajoute une question pour mieux calculer l'AL primo accédant

### DIFF
--- a/app/js/controllers/foyer/logement.js
+++ b/app/js/controllers/foyer/logement.js
@@ -11,6 +11,7 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
     $scope.demandeur = SituationService.getDemandeur($scope.situation);
 
     var logement = $scope.logement = LogementService.getLogementVariables(menage.statut_occupation_logement);
+    logement.pretSigneAvant2018 = moment(menage.aide_logement_date_pret_conventionne, 'YYYY-MM-DD').get('year') < 2018;
 
     function getMostPopulatedCity(cities) {
         return _.maxBy(cities, 'population') || (cities.length && cities[0]) || {};
@@ -95,6 +96,10 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
         return (logement.type == 'heberge') && (! $scope.captureHabiteChezParents() || angular.isDefined($scope.demandeur.habite_chez_parents));
     };
 
+    $scope.capturePretSigneAvant2018 = function() {
+        return logement.type == 'proprietaire' && logement.primoAccedant && (menage.loyer && menage.loyer > 0);
+    };
+
     $scope.captureLoyer = function() {
         if (logement.type == 'heberge') {
             return false;
@@ -159,6 +164,7 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
         $scope.submitted = true;
         if (form.$valid && $scope.isAdresseValid()) {
             menage.statut_occupation_logement = LogementService.getStatutOccupationLogement(logement);
+            menage.aide_logement_date_pret_conventionne = logement.pretSigneAvant2018 ? '2017-12-31' : '2018-01-01';
             $scope.$emit('logement');
         }
     };

--- a/app/js/controllers/foyer/logement.js
+++ b/app/js/controllers/foyer/logement.js
@@ -97,7 +97,7 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
     };
 
     $scope.capturePretSigneAvant2018 = function() {
-        return logement.type == 'proprietaire' && logement.primoAccedant && (menage.loyer && menage.loyer > 0);
+        return logement.type == 'proprietaire' && logement.primoAccedant && (menage && menage.loyer > 0);
     };
 
     $scope.captureLoyer = function() {

--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -69,8 +69,10 @@ angular.module('ddsCommon').factory('SituationService', function($http, $session
                 dateDeValeur: moment().format(),
                 famille: {},
                 foyer_fiscal: {},
-                menage: {},
-                version: 5,
+                menage: {
+                    aide_logement_date_pret_conventionne: '2017-12-31'
+                },
+                version: 6,
             };
         },
 

--- a/app/views/partials/foyer/logement.html
+++ b/app/views/partials/foyer/logement.html
@@ -121,6 +121,10 @@
       </div>
     </div>
 
+    <yes-no-question model="logement.pretSigneAvant2018" ng-if="capturePretSigneAvant2018()">
+      <question>Avez-vous signé votre prêt <strong>avant</strong> 2018 ?</question>
+    </yes-no-question>
+
     <div class="row" ng-show="captureCodePostal()">
 
       <div class="col-sm-6">

--- a/app/views/partials/foyer/logement.html
+++ b/app/views/partials/foyer/logement.html
@@ -122,7 +122,7 @@
     </div>
 
     <yes-no-question model="logement.pretSigneAvant2018" ng-if="capturePretSigneAvant2018()">
-      <question>Avez-vous signé votre prêt <strong>avant</strong> 2018 ?</question>
+      <question>Avez-vous signé votre prêt <strong>avant</strong> le 1er janvier 2018 ?</question>
     </yes-no-question>
 
     <div class="row" ng-show="captureCodePostal()">

--- a/backend/lib/migrations/toV6.js
+++ b/backend/lib/migrations/toV6.js
@@ -1,0 +1,16 @@
+/*
+ * Add default value for menage.aide_logement_date_pret_conventionne
+ */
+
+var VERSION = 6;
+
+module.exports = {
+    function: function(situation) {
+        if (!situation.menage.aide_logement_date_pret_conventionne) {
+            situation.menage.aide_logement_date_pret_conventionne = '2017-12-31';
+        }
+
+        return situation;
+    },
+    version: VERSION
+};

--- a/backend/lib/openfisca/mapping/index.js
+++ b/backend/lib/openfisca/mapping/index.js
@@ -105,8 +105,10 @@ function applyHeuristicsAndFix(testCase, dateDeValeur) {
 
     var menage = _.assign({}, {
         logement_conventionne: {},
+        aide_logement_date_pret_conventionne: {}
     }, testCase.menages._);
     menage.logement_conventionne[thisMonth] = menage.statut_occupation_logement && menage.statut_occupation_logement[thisMonth] == 'primo_accedant' && menage.loyer && menage.loyer[thisMonth] == 0;
+    menage.aide_logement_date_pret_conventionne[thisMonth] = '2017-12-31';
 
     testCase.menages._ = menage;
     return testCase;

--- a/backend/lib/openfisca/mapping/index.js
+++ b/backend/lib/openfisca/mapping/index.js
@@ -105,10 +105,8 @@ function applyHeuristicsAndFix(testCase, dateDeValeur) {
 
     var menage = _.assign({}, {
         logement_conventionne: {},
-        aide_logement_date_pret_conventionne: {}
     }, testCase.menages._);
     menage.logement_conventionne[thisMonth] = menage.statut_occupation_logement && menage.statut_occupation_logement[thisMonth] == 'primo_accedant' && menage.loyer && menage.loyer[thisMonth] == 0;
-    menage.aide_logement_date_pret_conventionne[thisMonth] = '2017-12-31';
 
     testCase.menages._ = menage;
     return testCase;

--- a/backend/lib/openfisca/mapping/index.js
+++ b/backend/lib/openfisca/mapping/index.js
@@ -104,11 +104,9 @@ function applyHeuristicsAndFix(testCase, dateDeValeur) {
     var thisMonth = common.getPeriods(dateDeValeur).thisMonth;
 
     var menage = _.assign({}, {
-        logement_conventionne: {},
-        aide_logement_date_pret_conventionne: {}
+        logement_conventionne: {}
     }, testCase.menages._);
     menage.logement_conventionne[thisMonth] = menage.statut_occupation_logement && menage.statut_occupation_logement[thisMonth] == 'primo_accedant' && menage.loyer && menage.loyer[thisMonth] == 0;
-    menage.aide_logement_date_pret_conventionne[thisMonth] = '2017-12-31';
 
     testCase.menages._ = menage;
     return testCase;

--- a/backend/lib/openfisca/mapping/last3MonthsDuplication.js
+++ b/backend/lib/openfisca/mapping/last3MonthsDuplication.js
@@ -41,6 +41,7 @@ var menageProperties = [
     'loyer',
     'participation_frais',
     'statut_occupation_logement',
+    'aide_logement_date_pret_conventionne',
 ];
 
 function copyTo3PreviousMonths(testCase, dateDeValeur) {

--- a/backend/models/situation.js
+++ b/backend/models/situation.js
@@ -86,6 +86,7 @@ var menageDef = {
     nom_commune: String,
     participation_frais: Boolean,
     statut_occupation_logement: { type: String, enum: statutOccupationLogementValues },
+    aide_logement_date_pret_conventionne: String,
 };
 
 var situation = {


### PR DESCRIPTION
Par défaut, c'est **OUI** qui est sélectionné, pour conserver le comportement qui était dans `backend/lib/openfisca/mapping/index.js`.

<img width="856" alt="capture d ecran 2019-02-04 a 18 02 04" src="https://user-images.githubusercontent.com/1162230/52223920-06307800-28a7-11e9-8321-e87bcd1de3f4.png">

Fixes #761
