### PR TITLE
Évite un scroll horizontal

### DIFF
--- a/app/styles/droits-eligibles-list.scss
+++ b/app/styles/droits-eligibles-list.scss
@@ -160,6 +160,18 @@ $fa-font-path: '~font-awesome/fonts';
     flex-direction: row;
     justify-content: space-between;
     margin-bottom: 15px;
+
+    @media (max-width: $screen-sm-max) {
+      flex-wrap: wrap;
+      > .btn {
+        flex-grow: 1;
+        width: 50%;
+      }
+      .btn-secondary {
+        order: 3;
+      }
+    }
+
   }
 
   .alert-warning {


### PR DESCRIPTION
Ça se produit quand on affiche la prime d'activité, à cause du bouton "Démarches pour les professions agricoles"

<table>
<tr align="center">
<td>AVANT</td>
<td>APRÈS</td>
</tr>
<tr>
<td><img width="324" alt="capture d ecran 2019-02-04 a 18 26 28" src="https://user-images.githubusercontent.com/1162230/52226579-aab5b880-28ad-11e9-87f5-632e868bb098.png"></td>
<td><img width="326" alt="capture d ecran 2019-02-04 a 18 44 47" src="https://user-images.githubusercontent.com/1162230/52226592-b30df380-28ad-11e9-83bc-abe9c9570268.png"></td>
</tr>
</table>

