### PR TITLE
Mise à jour d'OpenFisca

### DIFF
--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,6 +1,6 @@
 gunicorn>=19.1.1
 Openfisca-France==34.7.1
-git+https://github.com/openfisca/openfisca-core.git@mitigate-cycle-and-simplify-cycle-detection-25.2.2#egg=openfisca-core [web-api]
+git+https://github.com/openfisca/openfisca-core.git@mitigate-cycle-and-simplify-cycle-detection-25.3.4#egg=openfisca-core [web-api]
 git+https://github.com/betagouv/openfisca-bacASable.git#egg=openfisca-BacASable
 git+https://github.com/betagouv/openfisca-paris.git@6efb387#egg=openfisca-paris
 git+https://github.com/betagouv/openfisca-brestmetropole.git@aefb613#egg=openfisca-BrestMetropole

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,5 +1,5 @@
 gunicorn>=19.1.1
-Openfisca-France==34.3.1
+Openfisca-France==34.7.1
 git+https://github.com/openfisca/openfisca-core.git@mitigate-cycle-and-simplify-cycle-detection-25.2.2#egg=openfisca-core [web-api]
 git+https://github.com/betagouv/openfisca-bacASable.git#egg=openfisca-BacASable
 git+https://github.com/betagouv/openfisca-paris.git@6efb387#egg=openfisca-paris

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,5 +1,5 @@
 gunicorn>=19.1.1
-Openfisca-France==34.7.1
+Openfisca-France==34.8.1
 git+https://github.com/openfisca/openfisca-core.git@mitigate-cycle-and-simplify-cycle-detection-25.3.4#egg=openfisca-core [web-api]
 git+https://github.com/betagouv/openfisca-bacASable.git#egg=openfisca-BacASable
 git+https://github.com/betagouv/openfisca-paris.git@6efb387#egg=openfisca-paris


### PR DESCRIPTION
Mise à jour d'OpenFisca (utilisation de la dernière version) afin d'intégrer la revalorisation du chèque énergie.