### PR TITLE
Met à jour la dépendance `codes-postaux`

### DIFF
--- a/app/js/controllers/foyer/logement.js
+++ b/app/js/controllers/foyer/logement.js
@@ -17,7 +17,7 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
     }
 
     function getSelectedCity() {
-        return _.find($scope.cities, { codeInsee: menage.depcom }) ||
+        return _.find($scope.cities, { codeCommune: menage.depcom }) ||
             getMostPopulatedCity($scope.cities);
     }
 
@@ -32,7 +32,7 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
             .then(function(cities) {
                 $scope.cities = cities;
                 var city = getSelectedCity();
-                menage.depcom = city.codeInsee;
+                menage.depcom = city.codeCommune;
                 menage.nom_commune = city.nomCommune;
                 if (! initial) {
                     famille.parisien = cityStartsWith('Paris');

--- a/app/js/controllers/foyer/logement.js
+++ b/app/js/controllers/foyer/logement.js
@@ -13,7 +13,7 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
     var logement = $scope.logement = LogementService.getLogementVariables(menage.statut_occupation_logement);
 
     function getMostPopulatedCity(cities) {
-        return _.maxBy(cities, 'population') || {};
+        return _.maxBy(cities, 'population') || (cities.length && cities[0]) || {};
     }
 
     function getSelectedCity() {

--- a/app/js/directives/etablissementsList.js
+++ b/app/js/directives/etablissementsList.js
@@ -5,7 +5,7 @@ angular.module('ddsApp').directive('etablissementsList', function() {
         restrict: 'E',
         templateUrl: '/partials/etablissements-list.html',
         scope: {
-            codeInsee: '=',
+            codeCommune: '=',
             codePostal: '='
         },
         controller: 'etablissementsListCtrl',
@@ -21,13 +21,13 @@ angular.module('ddsApp').controller('etablissementsListCtrl', function($http, $i
         var situation = SituationService.restoreLocal();
 
         EtablissementService
-            .getEtablissements(situation, $scope.codePostal, $scope.codeInsee)
+            .getEtablissements(situation, $scope.codePostal, $scope.codeCommune)
             .then(function (etablissements) {
                 $scope.etablissements = etablissements;
             });
     }
 
-    ['codeInsee', 'codePostal'].forEach(function(key) {
+    ['codeCommune', 'codePostal'].forEach(function(key) {
         $scope.$watch(key, getEtablissements);
     });
 

--- a/app/js/services/etablissementService.js
+++ b/app/js/services/etablissementService.js
@@ -69,15 +69,15 @@ angular.module('ddsCommon').factory('EtablissementService', function($http, City
         return defaultEtablissementTypes.concat(etablissementTypes);
     }
 
-    function getEtablissements(situation, codePostal, codeInsee) {
+    function getEtablissements(situation, codePostal, codeCommune) {
         return CityService
             .getCities(codePostal)
-            .then(function(cities) { return _.find(cities, { codeInsee: codeInsee }); })
+            .then(function(cities) { return _.find(cities, { codeCommune: codeCommune }); })
             .then(function(city) { return city; })
             .then(function(city) {
                 var etablissementTypes = getEtablissementTypesBySituation(situation);
 
-                return $http.get('https://etablissements-publics.api.gouv.fr/v3/communes/' + city.codeInsee + '/' + etablissementTypes.join('+'));
+                return $http.get('https://etablissements-publics.api.gouv.fr/v3/communes/' + city.codeCommune + '/' + etablissementTypes.join('+'));
             })
             .then(function(response) { return response.data.features; }, function() { return []; })
             .then(function(etablissements) {

--- a/app/views/partials/foyer/logement.html
+++ b/app/views/partials/foyer/logement.html
@@ -157,7 +157,7 @@
                 class="form-control"
                 required
                 ng-change="changeNomCommune()"
-                ng-options="city.codeInsee as city.nomCommune for city in cities"
+                ng-options="city.codeCommune as city.nomCommune for city in cities"
                 ng-model="menage.depcom"
                 id="city">
               </select>

--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -80,7 +80,7 @@
     ></droit-eligibles-details>
 
   <div class="print-hidden">
-    <etablissements-list code-postal="situation.menage.code_postal" code-insee="situation.menage.depcom"></etablissements-list>
+    <etablissements-list code-postal="situation.menage.code_postal" code-commune="situation.menage.depcom"></etablissements-list>
 
     <div>
       <h4 ng-show="! (droitsInjectes | isEmpty)">Vous avez indiqué ces aides au cours la simulation et elles n'ont pas été recalculées</h4>

--- a/backend/lib/migrations/initial.js
+++ b/backend/lib/migrations/initial.js
@@ -71,7 +71,7 @@ exports.persistedSituationPretransformationUpdate = function persistedSituationP
 
     if (! situation.logement.adresse) {
         situation.logement.adresse = {
-            codeInsee: '-1',
+            codeCommune: '-1',
             code_postal: '-1',
         };
     }
@@ -202,7 +202,7 @@ exports.migratePersistedSituation = function(sourceSituation) {
     situation.menage = {
         code_postal: sourceSituation.logement.adresse.codePostal,
         coloc: sourceSituation.logement.colocation,
-        depcom: sourceSituation.logement.adresse.codeInsee,
+        depcom: sourceSituation.logement.adresse.codeCommune,
         loyer: sourceSituation.logement.loyer,
         logement_chambre: sourceSituation.logement.isChambre,
         participation_frais: sourceSituation.logement.participationFrais,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2410,8 +2410,12 @@
       "dev": true
     },
     "codes-postaux": {
-      "version": "github:etalab/codes-postaux#003ea027941e7a40c6094c7a02e7299d37619712",
-      "from": "github:etalab/codes-postaux#003ea027941e7a40c6094c7a02e7299d37619712"
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/codes-postaux/-/codes-postaux-3.1.1.tgz",
+      "integrity": "sha512-bWBfVQiyFrT+XgUhAf+FoDMfiWkSUKREa6YAbtra49HKigPkjj9RNTWmvxVuwIfV8Oz6B7FxFBjKXUcy2LbpAg==",
+      "requires": {
+        "lodash": "^4.17.11"
+      }
     },
     "coffeescript": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bluebird": "^3.5.1",
     "body-parser": "^1.9.0",
     "cleave.js": "~0.7.15",
-    "codes-postaux": "github:etalab/codes-postaux#003ea027941e7a40c6094c7a02e7299d37619712",
+    "codes-postaux": "^3.0.0",
     "consolidate": "^0.15.1",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.4",

--- a/test/integration/base-suite/5 - Declare being SDS scenario.js
+++ b/test/integration/base-suite/5 - Declare being SDS scenario.js
@@ -19,7 +19,7 @@ steps: [
     },
     LogementFormComponent.setZipCodeInput('61500'),
     {
-        'LogementFormComponent.city': /SÉES/i,
+        'LogementFormComponent.city': /Aunay/i,
     },
     LogementFormComponent.submit(),
     {

--- a/test/spec/services/cityService.js
+++ b/test/spec/services/cityService.js
@@ -13,7 +13,7 @@ describe('CityService', function() {
             $httpBackend
                 .whenGET('/api/outils/communes/75019')
                 .respond(200, JSON.stringify([{
-                    codeInsee: '75119',
+                    codeCommune: '75119',
                     codePostal: '75019',
                     nomCommune: 'paris 19',
                 }]));
@@ -21,12 +21,12 @@ describe('CityService', function() {
             $httpBackend
                 .whenGET('/api/outils/communes/33610')
                 .respond(200, JSON.stringify([{
-                    codeInsee: "33090",
+                    codeCommune: "33090",
                     codePostal: "33610",
                     nomCommune: "CANEJAN",
                 },
                 {
-                    codeInsee: "33122",
+                    codeCommune: "33122",
                     codePostal: "33610",
                     nomCommune: "CESTAS",
                 }]));


### PR DESCRIPTION
La version qui était utilisée a été supprimée.

Il n'est plus possible de sélectionner la ville la plus peuplée (cf. https://github.com/etalab/codes-postaux/issues/5) mais il faut réparer le déploiement continu.

C'est une PR de secours.

Par souci de cohérence, j'ai renommé `codeInsee` en `codeCommune` comme ça a été fait dans le paquet `codes-postaux`. 