### PR TITLE
Supprime l'utilisation de la réforme de simulation

### DIFF
--- a/backend/lib/openfisca/mapping/individu/index.js
+++ b/backend/lib/openfisca/mapping/individu/index.js
@@ -61,14 +61,6 @@ var individuSchema = {
         fn: function(specificSituations) {
             return specificSituations.indexOf('inapte_travail') >= 0;
         }
-    },
-    date_simulation: {
-        fn: function (individu, situation) {
-            var obj = {};
-            var month = moment(situation.dateDeValeur).format('YYYY-MM');
-            obj[month] = month;
-            return obj;
-        }
     }
 };
 

--- a/openfisca/api.py
+++ b/openfisca/api.py
@@ -7,7 +7,7 @@ extensions = ['openfisca_bacASable', 'openfisca_paris', 'openfisca_brestmetropol
 tax_benefit_system = build_tax_benefit_system(
     country_package_name = country_package,
     extensions = extensions,
-    reforms = ['openfisca_bacASable.simulation_reform.simulation_reform']
+    reforms = []
 )
 
 application = create_app(tax_benefit_system)


### PR DESCRIPTION
* Superflue suite au recalcul des prestations sur 4 mois