### PR TITLE
Change de librairie pour la gestion des communes

### DIFF
--- a/app/js/controllers/foyer/logement.js
+++ b/app/js/controllers/foyer/logement.js
@@ -18,7 +18,7 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
     }
 
     function getSelectedCity() {
-        return _.find($scope.cities, { codeCommune: menage.depcom }) ||
+        return _.find($scope.cities, { code: menage.depcom }) ||
             getMostPopulatedCity($scope.cities);
     }
 
@@ -33,8 +33,8 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
             .then(function(cities) {
                 $scope.cities = cities;
                 var city = getSelectedCity();
-                menage.depcom = city.codeCommune;
-                menage.nom_commune = city.nomCommune;
+                menage.depcom = city.code;
+                menage.nom_commune = city.nom;
                 if (! initial) {
                     famille.parisien = cityStartsWith('Paris');
                 }
@@ -149,7 +149,7 @@ angular.module('ddsApp').controller('FoyerLogementCtrl', function($scope, $http,
     };
 
     $scope.changeNomCommune = function() {
-        menage.nom_commune = getSelectedCity().nomCommune;
+        menage.nom_commune = getSelectedCity().nom;
     };
 
     $scope.isResidentMayotte = function isResidentMayotte() {

--- a/app/js/services/cityService.js
+++ b/app/js/services/cityService.js
@@ -2,9 +2,9 @@
 
 angular.module('ddsCommon').factory('CityService', function($http) {
     function sortByName(aCity, bCity) {
-        if (aCity.nomCommune < bCity.nomCommune)
+        if (aCity.nom < bCity.nom)
             return -1;
-        if (aCity.nomCommune > bCity.nomCommune)
+        if (aCity.nom > bCity.nom)
             return 1;
 
         return 0;

--- a/app/views/partials/foyer/logement.html
+++ b/app/views/partials/foyer/logement.html
@@ -161,7 +161,7 @@
                 class="form-control"
                 required
                 ng-change="changeNomCommune()"
-                ng-options="city.codeCommune as city.nomCommune for city in cities"
+                ng-options="city.code as city.nom for city in cities"
                 ng-model="menage.depcom"
                 id="city">
               </select>

--- a/backend/controllers/outils.js
+++ b/backend/controllers/outils.js
@@ -1,5 +1,24 @@
-var codesPostaux = require('codes-postaux');
+var communes = require('@etalab/decoupage-administratif/data/communes.json');
+var index = {};
+
+communes.forEach(function(commune) {
+    if (!commune.codesPostaux) {
+        return;
+    }
+
+    commune.codesPostaux.forEach(function(codePostal) {
+        if (!(codePostal in index)) {
+            index[codePostal] = [];
+        }
+
+        index[codePostal].push(commune);
+    });
+});
+
+function find(postalCode) {
+    return index[postalCode] || [];
+}
 
 exports.communes = function(req, res) {
-    res.send(codesPostaux.find(req.params.codePostal));
+    res.send(find(req.params.codePostal));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -934,6 +934,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@etalab/decoupage-administratif": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@etalab/decoupage-administratif/-/decoupage-administratif-0.3.0.tgz",
+      "integrity": "sha512-tpXVQ2kv8cZPe9DXfflsKK4xF18VwNTitpgnj2nvZO1jmg5co3wDg8qGucSVoPK6LTzD3ON7U6E1yxNX9s4/XQ=="
+    },
     "@uirouter/core": {
       "version": "5.0.21",
       "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-5.0.21.tgz",
@@ -2409,14 +2414,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
-    },
-    "codes-postaux": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/codes-postaux/-/codes-postaux-3.1.1.tgz",
-      "integrity": "sha512-bWBfVQiyFrT+XgUhAf+FoDMfiWkSUKREa6YAbtra49HKigPkjj9RNTWmvxVuwIfV8Oz6B7FxFBjKXUcy2LbpAg==",
-      "requires": {
-        "lodash": "^4.17.11"
-      }
     },
     "coffeescript": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   ],
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
+    "@etalab/decoupage-administratif": "^0.3.0",
     "angulartics": "^1.3.0",
     "angulartics-piwik": "^1.0.4",
     "basic-auth": "^2.0.0",
     "bluebird": "^3.5.1",
     "body-parser": "^1.9.0",
-    "codes-postaux": "^3.0.0",
     "consolidate": "^0.15.1",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.4",

--- a/test/integration/base-suite/5 - Declare being SDS scenario.js
+++ b/test/integration/base-suite/5 - Declare being SDS scenario.js
@@ -19,7 +19,7 @@ steps: [
     },
     LogementFormComponent.setZipCodeInput('61500'),
     {
-        'LogementFormComponent.city': /Aunay/i,
+        'LogementFormComponent.city': /Sées/i,
     },
     LogementFormComponent.submit(),
     {

--- a/test/spec/services/cityService.js
+++ b/test/spec/services/cityService.js
@@ -13,22 +13,22 @@ describe('CityService', function() {
             $httpBackend
                 .whenGET('/api/outils/communes/75019')
                 .respond(200, JSON.stringify([{
-                    codeCommune: '75119',
-                    codePostal: '75019',
-                    nomCommune: 'paris 19',
+                    code: '75119',
+                    codesPostaux: ['75019'],
+                    nom: 'paris 19',
                 }]));
 
             $httpBackend
                 .whenGET('/api/outils/communes/33610')
                 .respond(200, JSON.stringify([{
-                    codeCommune: "33090",
-                    codePostal: "33610",
-                    nomCommune: "CANEJAN",
+                    code: "33090",
+                    codesPostaux: ["33610"],
+                    nom: "CANEJAN",
                 },
                 {
-                    codeCommune: "33122",
-                    codePostal: "33610",
-                    nomCommune: "CESTAS",
+                    code: "33122",
+                    codesPostaux: ["33610"],
+                    nom: "CESTAS",
                 }]));
 
         });


### PR DESCRIPTION
Passe de [codes-postaux](https://www.npmjs.com/package/codes-postaux) à [@etalab/decoupage-administratif](https://www.npmjs.com/package/@etalab/decoupage-administratif) suite aux échanges sur https://github.com/etalab/codes-postaux/issues/5#issuecomment-467019463.