### PR TITLE
Rend l'API codes-postaux rétro-compatible

### DIFF
--- a/backend/controllers/outils.js
+++ b/backend/controllers/outils.js
@@ -6,6 +6,10 @@ communes.forEach(function(commune) {
         return;
     }
 
+    // Backward compatibility
+    commune.codeCommune = commune.code;
+    commune.nomCommune = commune.nom;
+
     commune.codesPostaux.forEach(function(codePostal) {
         if (!(codePostal in index)) {
             index[codePostal] = [];


### PR DESCRIPTION
Il faut mettre à jour `/opt/mes-aides/ui_target_revision`.
