### PR TITLE
Fixe l'utilisation de Puppeteer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9764,24 +9764,24 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.9.0.tgz",
-      "integrity": "sha512-GH4PmhJf9wBRAPvtJkEJLAvdNNOofZortmBZSj8cGWYni98GUFqsf66blOEfJbo5B8l0KG5HR2d/W2MejnUrzg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.13.0.tgz",
+      "integrity": "sha512-LUXgvhjfB/P6IOUDAKxOcbCz9ISwBLL9UpKghYrcBDwrOGx1m60y0iN2M64mdAUbT4+7oZM5DTxOW7equa2fxQ==",
       "requires": {
-        "debug": "^3.1.0",
+        "debug": "^4.1.0",
         "extract-zip": "^1.6.6",
         "https-proxy-agent": "^2.2.1",
         "mime": "^2.0.3",
-        "progress": "^2.0.0",
+        "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
         "rimraf": "^2.6.1",
-        "ws": "^5.1.1"
+        "ws": "^6.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -9802,9 +9802,9 @@
           "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
         },
         "ws": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.0.tgz",
+          "integrity": "sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==",
           "requires": {
             "async-limiter": "~1.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "moment": "^2.24.0",
     "mongoose": "^4.13.18",
     "morgan": "~1.8.0",
-    "puppeteer": "1.9.0",
+    "puppeteer": "^1.11.0",
     "raven": "^2.6.4",
     "raven-js": "^3.26.3",
     "request-promise": "^4.2.2",

--- a/pm2_config.yaml
+++ b/pm2_config.yaml
@@ -8,3 +8,4 @@ apps:
         MONGODB_URL: mongodb://localhost/dds
         NODE_ENV: production
         PORT: 8000
+        CHROME_DEVEL_SANDBOX: /usr/local/sbin/chrome-devel-sandbox


### PR DESCRIPTION
En production il faut au moins la version `1.11.0`, pour que `setContent` attende bien que tout soit chargé. 

Déjà déployé en production. 

https://github.com/GoogleChrome/puppeteer/releases/tag/v1.11.0