### PR TITLE
Masque le bouton télécharger tant que les résultats ne sont pas affichés

### DIFF
--- a/app/js/controllers/foyer.js
+++ b/app/js/controllers/foyer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('ddsApp').controller('FoyerCtrl', function($scope, $state, $filter, $http, $location, $q, SituationService, IndividuService) {
+angular.module('ddsApp').controller('FoyerCtrl', function($scope, $state, $filter, $http, $location, $q, ResultatService, SituationService, IndividuService) {
     var situation = $scope.situation = SituationService.restoreLocal();
 
     $scope.restoreRemoteSituation = function(situationId) {
@@ -80,6 +80,11 @@ angular.module('ddsApp').controller('FoyerCtrl', function($scope, $state, $filte
     $scope.$on('patrimoine', function() {
         $scope.$broadcast('patrimoineCaptured');
         $state.go('foyer.resultat');
+    });
+
+    $scope.awaitingResults = ResultatService.isLoading();
+    $scope.$on('resultat:loading:changed', function(event, loading) {
+        $scope.awaitingResults = loading;
     });
 
     $scope.downloadAsPdf = function() {

--- a/app/js/controllers/resultat.js
+++ b/app/js/controllers/resultat.js
@@ -1,10 +1,14 @@
 'use strict';
 
 angular.module('ddsApp').controller('ResultatCtrl', function($analytics, $http, $scope, $sessionStorage, $stateParams, $window, CityService, ResultatService, SituationService, TrampolineService) {
-    $scope.awaitingResults = false;
     $scope.error = false;
     $scope.warning = false;
     $scope.warningMessage = false;
+
+    $scope.awaitingResults = ResultatService.isLoading();
+    $scope.$on('resultat:loading:changed', function(event, loading) {
+        $scope.awaitingResults = loading;
+    });
 
     function loadSituation() {
         if ($stateParams.situationId) { // If we want the result page for an already existing situation.
@@ -18,7 +22,7 @@ angular.module('ddsApp').controller('ResultatCtrl', function($analytics, $http, 
     function triggerEvaluation() {
         loadSituation()
             .then(function(situation) {
-                $scope.awaitingResults = true;
+                ResultatService.setLoading(true);
                 return situation;
             })
             .then(ResultatService.simulate)
@@ -53,7 +57,7 @@ angular.module('ddsApp').controller('ResultatCtrl', function($analytics, $http, 
                 $analytics.eventTrack('error', { label: $scope.error || $scope.situation._id });
             })
             .finally(function() {
-                $scope.awaitingResults = false;
+                ResultatService.setLoading(false);
 
                 $scope.yearMoins2 = moment($scope.situation.dateDeValeur).subtract(2, 'years').format('YYYY');
                 $scope.debutPeriode = moment($scope.situation.dateDeValeur).startOf('month').subtract(1, 'years').format('MMMM YYYY');

--- a/app/js/services/resultatService.js
+++ b/app/js/services/resultatService.js
@@ -1,6 +1,8 @@
 'use strict';
 
-angular.module('ddsApp').service('ResultatService', function($http, droitsDescription, CustomizationService) {
+angular.module('ddsApp').service('ResultatService', function($http, $rootScope, droitsDescription, CustomizationService) {
+
+    var _loading = false;
 
     /**
     * OpenFisca test cases separate ressources between two entities: individuals and families.
@@ -105,9 +107,22 @@ angular.module('ddsApp').service('ResultatService', function($http, droitsDescri
             });
     }
 
+    function setLoading(loading) {
+        if (loading !== _loading) {
+            $rootScope.$broadcast('resultat:loading:changed', loading);
+        }
+        _loading = loading;
+    }
+
+    function isLoading() {
+        return _loading;
+    }
+
     return {
         _computeAides: computeAides,  // exposed for testing only
         round: round, // exposed for testing only
-        simulate: simulate
+        simulate: simulate,
+        setLoading: setLoading,
+        isLoading: isLoading
     };
 });

--- a/app/views/partials/foyer/layout.html
+++ b/app/views/partials/foyer/layout.html
@@ -10,7 +10,7 @@
       <div ui-view="recap_situation" class="recap-situation well whiteframe-z1">
         <p class="text-center"><i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Chargement en cours…</p>
       </div>
-      <form method="post" id="download" ng-hide="$state.current.name !== 'foyer.resultat' || ! situation._id " class="hidden-xs">
+      <form method="post" id="download" ng-hide="awaitingResults || $state.current.name !== 'foyer.resultat' || ! situation._id" class="hidden-xs">
         <input type="hidden" name="basename" ng-value="situation._id">
         <input type="hidden" name="base64" ng-value="base64">
         <button type="submit" class="btn btn-default btn-block" ng-click="downloadAsPdf()"


### PR DESCRIPTION
Cela évite de télécharger un PDF vide.