### PR TITLE
Améliore la gestion des ressources définissables sur les 12 derniers mois et sur l'année fiscale de référence

### DIFF
--- a/app/js/services/ressourceService.js
+++ b/app/js/services/ressourceService.js
@@ -54,12 +54,14 @@ angular.module('ddsCommon').factory('RessourceService', function($http, MonthSer
         }
     }
 
+    var ressourcesForTrailingMonthsAndFiscalYear = categoriesRnc.filter(function(fiscalRessource) {
+        return fiscalRessource.sources && fiscalRessource.sources.indexOf(fiscalRessource.id) >= 0;
+    }).map(function(fiscalRessource) { return fiscalRessource.id; });
+
     function isSelectedForCurrentYear(ressource, ressourceIdOrType) {
-        // pensions_alimentaires_percues is a YM2 and current year ressource
-        // Hence that special treatment:
-        // A single value means that a YM2 value has been specified
+        // A single value means that ONLY a YM2 value has been specified
         // Multiple values means that CY values were specified
-        if ((ressourceIdOrType.id || ressourceIdOrType) == 'pensions_alimentaires_percues') {
+        if (ressourcesForTrailingMonthsAndFiscalYear.indexOf(ressourceIdOrType.id || ressourceIdOrType) >= 0) {
             return _.keys(ressource).length > 1;
         }
 


### PR DESCRIPTION
* Certaines ressources sont définissables sur les 12 derniers mois et sur l'année fiscale de référence.
* C'était le cas depuis longtemps des pensions_alimentaires_percues et plus récemment des revenus_locatifs
* En manipulant la simulation (ie. après avoir spécifié des revenus sur l'année fiscale), les revenus locatifs apparaisaient comme sélectionnés par l'usager pour les 12 derniers mois et cela par erreur

Fix #1166.


Pour répliquer le comportement gênant :
- Faire une simulation sans ressources
- Déclarer 1 € de revenus d'activité sur l'année fiscale de référence
- Retrouver sur la page Logement puis Valider pour arriver sur la page qui liste les ressources

Là, la catégorie revenus locatifs est sélectionnée à tord. 