### PR TITLE
Homogénéise la périodicité des ressources

### DIFF
--- a/app/js/constants/ressources.js
+++ b/app/js/constants/ressources.js
@@ -347,7 +347,8 @@
         },
         {
             id: 'frais_reels',
-            label: 'Frais réels déductibles'
+            label: 'Frais réels déductibles',
+            yearly: true,
         },
         {
             id: 'pensions_alimentaires_percues',
@@ -357,7 +358,8 @@
         {
             id: 'pensions_alimentaires_versees',
             label: 'Pensions alimentaires versées',
-            sources: ['pensions_alimentaires_versees_individu']
+            sources: ['pensions_alimentaires_versees_individu'],
+            yearly: true,
         },
         {
             id: 'revenus_locatifs',

--- a/backend/lib/openfisca/mapping/individu/pastResourcesProxy.js
+++ b/backend/lib/openfisca/mapping/individu/pastResourcesProxy.js
@@ -43,8 +43,23 @@ function extendFiscalDataBackward(individu, dateDeValeur) {
             return;
         }
 
-        var value = individu[ressource.id][fy];
-        individu[ressource.id][pfy] = value;
+        if (!_.isNumber(individu[ressource.id][fy])) {
+            return;
+        }
+
+        if (ressource.yearly) {
+            individu[ressource.id][pfy] = individu[ressource.id][fy];
+        } else {
+            var result = individu[ressource.id];
+            var monthlyValue = result[fy] / 12;
+
+            var months = [].concat(periods.fiscalYear12Months, periods.previousFiscalYear12Months);
+            months.forEach(function(month) {
+                result[month] = monthlyValue;
+            });
+
+            delete result[fy];
+        }
     });
 
 }

--- a/test/backend/openfisca/mapping/pastResourcesProxy.js
+++ b/test/backend/openfisca/mapping/pastResourcesProxy.js
@@ -30,7 +30,10 @@ describe('openfisca past resource proxy', function() {
             var individu = {
                 salaire_imposable: {
                     '2017': 12120
-                }
+                },
+                frais_reels: {
+                    '2017': 24240
+                },
             };
 
             beforeEach(function() {
@@ -38,7 +41,8 @@ describe('openfisca past resource proxy', function() {
             });
 
             it('populates previous fiscal year', function() {
-                expect(individu.salaire_imposable['2016']).toEqual(12120);
+                expect(individu.salaire_imposable['2016-01']).toEqual(1010);
+                expect(individu.frais_reels['2016']).toEqual(24240);
             });
         });
     });


### PR DESCRIPTION
* Particulièrement pertinent pour les ressources définies pour les 12 derniers mois et pour les périodes fiscales

* Nécessaire pour faire des évaluations avec OpenFisca sur plusieurs simulations vectorisées.