### PR TITLE
Ajoute des exemples de ressources

### DIFF
--- a/app/js/constants/ressources.js
+++ b/app/js/constants/ressources.js
@@ -4,31 +4,38 @@
     var ressourceCategories = [
         {
             id: 'revenusActivite',
-            label: 'Revenus d’activité'
+            label: 'Revenus d’activité',
+            help: 'Salaire, rémunération de stage, prime d’activité…',
         },
         {
             id: 'allocations',
-            label: 'Allocations'
+            label: 'Allocations',
+            help: 'Aides au logement, prestations familiales, revenu de solidarité active…',
         },
         {
             id: 'indemnites',
-            label: 'Indemnités'
+            label: 'Indemnités',
+            help: 'Indemnités journalières (maladie, maternité, etc.), indemnité de volontariat…',
         },
         {
             id: 'pensions',
-            label: 'Pensions'
+            label: 'Pensions',
+            help: 'Pension alimentaire, prestation de compensation (suite à séparation)…',
         },
         {
             id: 'rpns',
-            label: 'Revenus professionnels non salariés'
+            label: 'Revenus professionnels non salariés',
+            help: 'Auto-entrepreneur, profession libérale…',
         },
         {
             id: 'patrimoine',
-            label: 'Revenus du patrimoine'
+            label: 'Revenus du patrimoine',
+            help: 'Revenus locatifs et du capital',
         },
         {
             id: 'autre',
-            label: 'Autres'
+            label: 'Autres',
+            help: 'Bourses, dons, héritage et autres gains exceptionnels',
         }
     ];
 

--- a/app/js/controllers/foyer/ressources/types.js
+++ b/app/js/controllers/foyer/ressources/types.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('ddsApp').controller('FoyerRessourceTypesCtrl', function($scope, $stateParams, ressourceCategories, ressourceTypes, $state, RessourceService) {
+angular.module('ddsApp').controller('FoyerRessourceTypesCtrl', function($scope, $stateParams, ABTestingService, ressourceCategories, ressourceTypes, $state, RessourceService) {
 
     var momentDebutAnnee = moment($scope.situation.dateDeValeur).subtract(1, 'years');
     $scope.debutAnneeGlissante = momentDebutAnnee.format('MMMM YYYY');
@@ -10,6 +10,9 @@ angular.module('ddsApp').controller('FoyerRessourceTypesCtrl', function($scope, 
     var keyedRessourceTypes = _.keyBy(ressourceTypes, 'id');
     var filteredRessourceTypes = _.filter(ressourceTypes, RessourceService.isRessourceOnMainScreen);
     $scope.ressourceTypesByCategories = _.groupBy(filteredRessourceTypes, 'category');
+
+    var abtesting = ABTestingService.getEnvironment();
+    $scope.hideHelp = abtesting && abtesting.resourceHelp && abtesting.resourceHelp.value === "Hide";
 
     $scope.shouldInitiallyOpen = function(category) {
         var selectedRessourceTypes = Object.keys($scope.selectedRessourceTypes);

--- a/app/js/services/abtestingService.js
+++ b/app/js/services/abtestingService.js
@@ -31,6 +31,10 @@ angular.module('ddsCommon').factory('ABTestingService', function($localStorage, 
         $localStorage.ABTesting.datepicker.value = $localStorage.ABTesting.datepicker.value || (Math.random() > 0.5 ? 'Current' : 'New');
         //$localStorage.ABTesting.datepicker.deleted = true;
 
+        $localStorage.ABTesting.resourceHelp = $localStorage.ABTesting.resourceHelp || { index: 3 };
+        $localStorage.ABTesting.resourceHelp.value = $localStorage.ABTesting.resourceHelp.value || (Math.random() > 0.5 ? 'Show' : 'Hide');
+        //$localStorage.ABTesting.resourceHelp.deleted = true;
+
         _.forEach($localStorage.ABTesting, function(data, name) {
             if (data.deleted) {
                 $analytics.deleteCustomVariable(data.index, 'visit');

--- a/app/styles/front.scss
+++ b/app/styles/front.scss
@@ -97,14 +97,13 @@ $rpns-light: #a8a1c8;
 }
 
 @mixin ressource-category-capture($color-light) {
-  border: 1px solid $color-light;
+  border: 4px solid $color-light;
   border-left-width: 4px;
   margin-bottom: 10px;
 
   .panel-heading {
     margin: 0;
-    padding-left: 10px;
-    background-color: lighten($color-light, 10%);
+    padding: 0;
     color: #333;
     cursor: pointer;
     user-select: none;
@@ -112,6 +111,47 @@ $rpns-light: #a8a1c8;
     .panel-title {
       font-weight: 400;
       font-size: 21px;
+
+      & > a:hover,
+      & > a:active,
+      & > a:focus,
+      & > a:visited {
+        text-decoration: none;
+      }
+
+      & > a:hover {
+        .panel-title-ressource-category {
+          background-color: lighten($color-light, 5%);
+        }
+      }
+
+      &-ressource-category {
+        display: block;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 10px 15px;
+        background-color: lighten($color-light, 10%);
+
+        & > *:first-child {
+          flex: 10;
+        }
+        & > *:last-child {
+          flex: 2;
+          text-align: right;
+        }
+
+        &-name {
+          display: block;
+          margin-bottom: 5px;
+        }
+        &-help {
+          display: block;
+          font-size: 14px;
+          color: darken($color-light, 55%);
+        }
+      }
+
     }
   }
 }

--- a/app/styles/resources.css
+++ b/app/styles/resources.css
@@ -16,10 +16,6 @@
 }
 
 @media (max-width: 768px) {
-    .button-grid {
-        flex-direction: column;
-    }
-
     .button-grid label {
         width: 100%;
     }

--- a/app/views/partials/foyer/ressources/types.html
+++ b/app/views/partials/foyer/ressources/types.html
@@ -13,14 +13,17 @@
           is-open="status.open"
           ng-init="status.open = shouldInitiallyOpen(category)">
           <uib-accordion-heading>
-            <div>
+            <span class="panel-title-ressource-category">
+              <span>
+                <span class="panel-title-ressource-category-name">{{ category.label }}</span>
+                <span class="panel-title-ressource-category-help">{{ category.help }}</span>
+              </span>
               <i class="fa"
                 aria-hidden="true"
                 role="presentation"
                 ng-class="{'fa-chevron-down': status.open, 'fa-chevron-right': !status.open}">
               </i>
-              {{ category.label }}
-            </div>
+            </span>
           </uib-accordion-heading>
           <div class="button-grid">
             <label ng-repeat="ressourceType in ressourceTypesByCategories[category.id]| orderBy:['positionInList','label']"

--- a/app/views/partials/foyer/ressources/types.html
+++ b/app/views/partials/foyer/ressources/types.html
@@ -16,7 +16,7 @@
             <span class="panel-title-ressource-category">
               <span>
                 <span class="panel-title-ressource-category-name">{{ category.label }}</span>
-                <span class="panel-title-ressource-category-help">{{ category.help }}</span>
+                <span ng-hide="hideHelp" class="panel-title-ressource-category-help">{{ category.help }}</span>
               </span>
               <i class="fa"
                 aria-hidden="true"


### PR DESCRIPTION
Fixes #1165

Premier essai naïf, en reprenant automatiquement les 2 premières ressources de la liste. 
Pensez-vous qu'il faut un texte dédié ? 
Pas encore adapté pour mobile. 

<img width="860" alt="Capture d’écran 2019-03-26 à 11 46 14" src="https://user-images.githubusercontent.com/1162230/54991358-10c0e100-4fbd-11e9-909f-4aa5a87ce81b.png">

Je ne suis pas certain pour l'UI. 
Dans tous les cas, un tooltip ne me semble pas adapté car pas accessible sur mobile. 
Autre idée d'UI : une barre de deuxième niveau, pour éviter les retours à la ligne. 
