### PR TITLE
Répare la gestion des dates invalides

### DIFF
--- a/backend/lib/openfisca/mapping/individu/index.js
+++ b/backend/lib/openfisca/mapping/individu/index.js
@@ -69,7 +69,7 @@ var individuSchema = {
 };
 
 function isNotValidValue(value) {
-    return _.isNaN(value) || _.isUndefined(value) || value === null;
+    return _.isNaN(value) || _.isUndefined(value) || value === null || value === "Invalid date";
 }
 
 function buildOpenFiscaIndividu(mesAidesIndividu, situation) {


### PR DESCRIPTION
En l'état lorsqu'une date arrive `null`, ça devient `Invalid date` et OpenFisca crashes.