### PR TITLE
Ajoute un choix explicite pour l'absence de situation particulière

### DIFF
--- a/app/js/controllers/foyer/individuForm.js
+++ b/app/js/controllers/foyer/individuForm.js
@@ -14,7 +14,7 @@ function findIndividu(individus, role, params) {
     return _.find(individus, predicate);
 }
 
-angular.module('ddsApp').controller('FoyerIndividuFormCtrl', function($scope, $stateParams, individuRole, situationsFamiliales, specificSituations, SituationService, IndividuService) {
+angular.module('ddsApp').controller('FoyerIndividuFormCtrl', function($scope, $stateParams, individuRole, situationsFamiliales, specificSituations, ABTestingService, SituationService, IndividuService) {
 
     $scope.specificSituations = specificSituations;
     $scope.situationsFamiliales = situationsFamiliales;
@@ -22,6 +22,11 @@ angular.module('ddsApp').controller('FoyerIndividuFormCtrl', function($scope, $s
     $scope.currentYear = $scope.today.format('YYYY');
     $scope.maxAgeYears = 130;
     $scope.minBirthDate = moment().subtract($scope.maxAgeYears, 'years');
+
+    var abtesting = ABTestingService.getEnvironment();
+
+    $scope.noSpecificSituationCheckbox =
+        abtesting && abtesting.noSpecificSituationCheckbox && abtesting.noSpecificSituationCheckbox.value === 'Show';
 
     if (individuRole == 'enfant') {
         $scope.displayCancelButton = true;

--- a/app/js/services/abtestingService.js
+++ b/app/js/services/abtestingService.js
@@ -35,6 +35,10 @@ angular.module('ddsCommon').factory('ABTestingService', function($localStorage, 
         $localStorage.ABTesting.resourceHelp.value = $localStorage.ABTesting.resourceHelp.value || (Math.random() > 0.5 ? 'Show' : 'Hide');
         //$localStorage.ABTesting.resourceHelp.deleted = true;
 
+        $localStorage.ABTesting.noSpecificSituationCheckbox = $localStorage.ABTesting.noSpecificSituationCheckbox || { index: 4 };
+        $localStorage.ABTesting.noSpecificSituationCheckbox.value = $localStorage.ABTesting.noSpecificSituationCheckbox.value || (Math.random() > 0.5 ? 'Show' : 'Hide');
+        //$localStorage.ABTesting.noSpecificSituationCheckbox.deleted = true;
+
         _.forEach($localStorage.ABTesting, function(data, name) {
             if (data.deleted) {
                 $analytics.deleteCustomVariable(data.index, 'visit');

--- a/app/views/partials/foyer/individu-form.html
+++ b/app/views/partials/foyer/individu-form.html
@@ -113,10 +113,11 @@
   </div>
 
   <div class="form-group">
-    <label class="control-label col-sm-4" id="situations-particulieres">
+    <label class="control-label col-sm-4">
       <span ng-if="individu.role == 'demandeur'">Vous êtes</span>
       <span ng-if="individu.role == 'conjoint'">Votre conjoint·e est</span>
       <span ng-if="individu.role == 'enfant'">Il ou elle est</span>
+      <span class="help-block">Plusieurs choix possibles</span>
     </label>
     <div class="col-sm-8">
       <div class="checkbox" ng-if="captureGardeAlternee">
@@ -137,8 +138,14 @@
           Enceinte
         </label>
       </div>
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="individu.no_specific_situation">
+          Je ne suis dans aucune de ces situations
+        </label>
+      </div>
 
-      <p class="help-block">Validez directement si vous n'êtes dans aucune de ces situations.</p>
+
     </div>
   </div>
 

--- a/app/views/partials/foyer/individu-form.html
+++ b/app/views/partials/foyer/individu-form.html
@@ -144,6 +144,7 @@
           Je ne suis dans aucune de ces situations
         </label>
       </div>
+      <p class="help-block" ng-if="! noSpecificSituationCheckbox">Validez directement si vous n'êtes dans aucune de ces situations.</p>
     </div>
   </div>
 

--- a/app/views/partials/foyer/individu-form.html
+++ b/app/views/partials/foyer/individu-form.html
@@ -138,14 +138,12 @@
           Enceinte
         </label>
       </div>
-      <div class="checkbox">
+      <div class="checkbox" ng-if="noSpecificSituationCheckbox">
         <label>
           <input type="checkbox" ng-model="individu.no_specific_situation">
           Je ne suis dans aucune de ces situations
         </label>
       </div>
-
-
     </div>
   </div>
 


### PR DESCRIPTION
Fixes #1187 

@guillett je pense qu'il n'est pas utile de stocker la clé `no_specific_situation` en base de données, qu'en penses-tu ? On ne pourra pas faire de migration de toutes façons. 

<img width="862" alt="Capture d’écran 2019-04-09 à 14 26 22" src="https://user-images.githubusercontent.com/1162230/55800357-d9c9ef80-5ad3-11e9-8a87-8d245658a1b5.png">
