### PR TITLE
Affiche un fenêtre modale d'aide pour la Prime d'Activité

### DIFF
--- a/app/js/directives/droitsEligiblesList.js
+++ b/app/js/directives/droitsEligiblesList.js
@@ -121,8 +121,7 @@ angular.module('ddsApp')
                 var isHebergeParticipeFrais = SituationService.isHebergeParticipeFrais(situation);
                 var isPpa = scope.droit.id === 'ppa';
 
-                scope.showUnexpected =
-                    attributes.hasOwnProperty('unexpected') && (isPpa && (isProprietaireAvecPretEnCours || isHebergeParticipeFrais));
+                scope.showUnexpected = attributes.hasOwnProperty('unexpected') && isPpa;
 
                 scope.openModal = function() {
                     $uibModal.open({

--- a/app/js/directives/droitsEligiblesList.js
+++ b/app/js/directives/droitsEligiblesList.js
@@ -60,6 +60,20 @@ angular.module('ddsApp').controller('droitsEligiblesListCtrl', function($scope) 
 
 });
 
+angular.module('ddsApp').controller('ppaHelpCtrl', function($scope, $uibModalInstance, SituationService) {
+
+    var situation = SituationService.restoreLocal();
+
+    $scope.isProprietaireAvecPretEnCours =
+        SituationService.isProprietaireAvecPretEnCours(situation);
+    $scope.isHebergeParticipeFrais =
+        SituationService.isHebergeParticipeFrais(situation);
+
+    $scope.closeModal = function () {
+        $uibModalInstance.dismiss('cancel');
+    };
+});
+
 var controllerOptions = function(templateUrl) {
     return function() {
         return {
@@ -87,18 +101,37 @@ angular.module('ddsApp')
     .directive('droitNonEligiblesList', controllerOptions('/partials/droits-non-eligibles-list.html'));
 
 angular.module('ddsApp')
-    .directive('droitMontant', function() {
+    .directive('droitMontant', function($uibModal, SituationService) {
         return {
             restrict: 'E',
             templateUrl: '/partials/droit-montant.html',
             scope: {
                 droit: '=',
             },
-            link: function(scope) {
+            link: function(scope, element, attributes) {
+
                 scope.isNumber = _.isNumber;
                 scope.isString = _.isString;
                 scope.getFractionSize = function(droit) {
                     return droit.floorAt < 1 ? 2 : 0;
+                };
+
+                var situation = SituationService.restoreLocal();
+                var isProprietaireAvecPretEnCours = SituationService.isProprietaireAvecPretEnCours(situation);
+                var isHebergeParticipeFrais = SituationService.isHebergeParticipeFrais(situation);
+                var isPpa = scope.droit.id === 'ppa';
+
+                scope.showUnexpected =
+                    attributes.hasOwnProperty('unexpected') && (isPpa && (isProprietaireAvecPretEnCours || isHebergeParticipeFrais));
+
+                scope.openModal = function() {
+                    $uibModal.open({
+                        animation: true,
+                        ariaLabelledBy: 'modal-title',
+                        ariaDescribedBy: 'modal-body',
+                        templateUrl: '/partials/ppa-help.html',
+                        controller: 'ppaHelpCtrl',
+                    });
                 };
             }
         };

--- a/app/js/directives/droitsEligiblesList.js
+++ b/app/js/directives/droitsEligiblesList.js
@@ -60,9 +60,9 @@ angular.module('ddsApp').controller('droitsEligiblesListCtrl', function($scope) 
 
 });
 
-angular.module('ddsApp').controller('ppaHelpCtrl', function($scope, $uibModalInstance, SituationService) {
-
-    var situation = SituationService.restoreLocal();
+angular.module('ddsApp').controller('ppaHelpCtrl', function($scope, $uibModalInstance, SituationService, situation, droit) {
+    $scope.situationId = situation._id;
+    $scope.droit = droit;
 
     $scope.isProprietaireAvecPretEnCours =
         SituationService.isProprietaireAvecPretEnCours(situation);
@@ -70,7 +70,7 @@ angular.module('ddsApp').controller('ppaHelpCtrl', function($scope, $uibModalIns
         SituationService.isHebergeParticipeFrais(situation);
 
     $scope.closeModal = function () {
-        $uibModalInstance.dismiss('cancel');
+        $uibModalInstance.close();
     };
 });
 
@@ -121,15 +121,24 @@ angular.module('ddsApp')
                 var isHebergeParticipeFrais = SituationService.isHebergeParticipeFrais(situation);
                 var isPpa = scope.droit.id === 'ppa';
 
-                scope.showUnexpected = attributes.hasOwnProperty('unexpected') && isPpa;
+                scope.showUnexpected = attributes.hasOwnProperty('unexpected') && (isPpa && (isProprietaireAvecPretEnCours || isHebergeParticipeFrais));
 
                 scope.openModal = function() {
                     $uibModal.open({
                         animation: true,
                         ariaLabelledBy: 'modal-title',
                         ariaDescribedBy: 'modal-body',
+                        size: 'lg',
                         templateUrl: '/partials/ppa-help.html',
                         controller: 'ppaHelpCtrl',
+                        resolve: {
+                            situation: function() {
+                                return situation;
+                            },
+                            droit: function() {
+                                return scope.droit;
+                            }
+                        }
                     });
                 };
             }

--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -221,5 +221,18 @@ angular.module('ddsCommon').factory('SituationService', function($http, $session
 
             }, undefined);
         },
+
+        isProprietaireAvecPretEnCours(situation) {
+            var isProprietaire =
+                ['primo_accedant', 'proprietaire'].includes(situation.menage.statut_occupation_logement);
+
+            return isProprietaire && situation.menage.loyer > 0;
+        },
+
+        isHebergeParticipeFrais(situation) {
+            return situation.menage.statut_occupation_logement === 'loge_gratuitement'
+                && situation.menage.participation_frais === true;
+        },
+
     };
 });

--- a/app/styles/droits-eligibles-list.scss
+++ b/app/styles/droits-eligibles-list.scss
@@ -115,8 +115,15 @@ $fa-font-path: '~font-awesome/fonts';
 }
 
 .droit-montant {
+
   display: inline-block;
   text-align: right;
+  color: $text-color;
+
+  &:hover,
+  &:active {
+    text-decoration: none;
+  }
 
   .montant {
     font-size: 18px;
@@ -129,6 +136,23 @@ $fa-font-path: '~font-awesome/fonts';
 
   .montant-detail {
     display: inline-block;
+  }
+
+  &--unexpected {
+    .droit-montant-label {
+      display: block;
+    }
+  }
+
+  .droit-montant-unexpected {
+    display: block;
+    padding: 4px 8px;
+    margin-top: 4px;
+    background-color: $brand-primary;
+    color: white;
+    font-size: $font-size-small;
+    text-align: center;
+    white-space: nowrap;
   }
 }
 

--- a/app/styles/droits-eligibles-list.scss
+++ b/app/styles/droits-eligibles-list.scss
@@ -145,14 +145,7 @@ $fa-font-path: '~font-awesome/fonts';
   }
 
   .droit-montant-unexpected {
-    display: block;
-    padding: 4px 8px;
-    margin-top: 4px;
-    background-color: $brand-primary;
-    color: white;
-    font-size: $font-size-small;
-    text-align: center;
-    white-space: nowrap;
+    cursor: pointer;
   }
 }
 

--- a/app/views/partials/droit-montant.html
+++ b/app/views/partials/droit-montant.html
@@ -10,7 +10,12 @@
       {{ droit.legend || (droit.isMontantAnnuel ? '/ an' : '/ mois') }}
     </span>
   </span>
-  <a class="droit-montant-unexpected" ng-click="openModal()" ng-if="showUnexpected">
+  <a class="droit-montant-unexpected"
+    ng-click="openModal()"
+    analytics-on="click"
+    analytics-name="{{ droit.label }}"
+    analytics-event="show-unexpected"
+    ng-if="showUnexpected">
     Montant inattendu ?
   </a>
 </span>

--- a/app/views/partials/droit-montant.html
+++ b/app/views/partials/droit-montant.html
@@ -1,4 +1,4 @@
-<a class="droit-montant droit-montant--unexpected" itemscope itemtype="http://schema.org/Offer" itemprop="offers">
+<span class="droit-montant droit-montant--unexpected" itemscope itemtype="http://schema.org/Offer" itemprop="offers">
   <span class="droit-montant-label">
     <span itemprop="price" ng-if="isNumber(droit.montant)" class="montant">
       {{ droit.montant | currency : ( droit.unit || '€' ) : getFractionSize(droit) }}
@@ -10,7 +10,7 @@
       {{ droit.legend || (droit.isMontantAnnuel ? '/ an' : '/ mois') }}
     </span>
   </span>
-  <span class="droit-montant-unexpected" ng-click="openModal()" ng-if="showUnexpected">
+  <a class="droit-montant-unexpected" ng-click="openModal()" ng-if="showUnexpected">
     Montant inattendu ?
-  </span>
-</a>
+  </a>
+</span>

--- a/app/views/partials/droit-montant.html
+++ b/app/views/partials/droit-montant.html
@@ -1,11 +1,16 @@
-<div class="droit-montant" itemscope itemtype="http://schema.org/Offer" itemprop="offers">
-  <span itemprop="price" ng-if="isNumber(droit.montant)" class="montant">
-    {{ droit.montant | currency : ( droit.unit || '€' ) : getFractionSize(droit) }}
+<a class="droit-montant droit-montant--unexpected" itemscope itemtype="http://schema.org/Offer" itemprop="offers">
+  <span class="droit-montant-label">
+    <span itemprop="price" ng-if="isNumber(droit.montant)" class="montant">
+      {{ droit.montant | currency : ( droit.unit || '€' ) : getFractionSize(droit) }}
+    </span>
+    <span ng-if="isString(droit.montant)">
+      <i class="fa fa-question-circle fa-2x"></i>
+    </span>
+    <span ng-if="isNumber(droit.montant)" class="montant-detail">
+      {{ droit.legend || (droit.isMontantAnnuel ? '/ an' : '/ mois') }}
+    </span>
   </span>
-  <span ng-if="isString(droit.montant)">
-    <i class="fa fa-question-circle fa-2x"></i>
+  <span class="droit-montant-unexpected" ng-click="openModal()" ng-if="showUnexpected">
+    Montant inattendu ?
   </span>
-  <span ng-if="isNumber(droit.montant)" class="montant-detail">
-    {{ droit.legend || (droit.isMontantAnnuel ? '/ an' : '/ mois') }}
-  </span>
-</div>
+</a>

--- a/app/views/partials/droits-eligibles-details.html
+++ b/app/views/partials/droits-eligibles-details.html
@@ -5,7 +5,7 @@
     <div class="droit-detail-heading">
       <h3 itemprop="name">{{ droit.label }}</h3>
       <div class="dotted-line"></div>
-      <droit-montant droit="droit" ng-if="droit.montant && (isString(droit.montant) || isNumber(droit.montant))"></droit-montant>
+      <droit-montant droit="droit" unexpected ng-if="droit.montant && (isString(droit.montant) || isNumber(droit.montant))"></droit-montant>
     </div>
 
     <div class="alert alert-warning print-hidden" ng-if="droit.isBaseRessourcesYearMoins2 && ! ressourcesYearMoins2Captured && ! isString(droit.montant)">

--- a/app/views/partials/ppa-help.html
+++ b/app/views/partials/ppa-help.html
@@ -1,22 +1,105 @@
-<div style="padding: 20px;">
+<style type="text/css">
+  .ppa-help {
+    padding: 20px;
+  }
 
+  .ppa-help .footer {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-content: stretch;
+  }
+
+  .ppa-help .footer > * {
+    flex-grow: 1;
+    margin: 0.1em;
+  }
+
+  .ppa-help p, .ppa-help div {
+    padding: 1em;
+  }
+
+  .ppa-help blockquote {
+    font-size: 1em;
+  }
+</style>
+
+<div class="ppa-help">
   <h2 class="text-center"><i class="fa fa-info-circle"></i> Prime d'activité</h2>
 
-  <div ng-if="isProprietaireAvecPretEnCours || isHebergeParticipeFrais">
-    <p>
+  <p>
     Vous avez indiqué être
-    <strong ng-if="isProprietaireAvecPretEnCours">propriétaire de votre logement principal avec un prêt en cours.</strong>
+    <strong ng-if="isProprietaireAvecPretEnCours">toujours en train de rembourser le crédit pour votre logement principal.</strong>
     <strong ng-if="isHebergeParticipeFrais">hébergé en participant aux frais du logement.</strong>
-    </p>
-    <p>
-    Sur le simulateur de la Caf, vous devez répondre "Non" à la question "Vous (ou votre conjoint) êtes propriétaire de votre logement principal ou êtes logés gratuitement". Répondez "oui" uniquement si
-    <span ng-if="isProprietaireAvecPretEnCours">vous n’avez <strong>aucun prêt pour votre habitation principale.</strong></span>
-    <span ng-if="isHebergeParticipeFrais">vous <strong>ne participez pas aux frais du logement.</strong></span>
-    </p>
-  </div>
-
-  <p class="text-center">
-    <a href ng-click="closeModal()">Fermer</a>
   </p>
 
+  <p>
+    Sur le simulateur de
+    <a href="http://www.caf.fr/allocataires/mes-services-en-ligne/estimer-vos-droits/simulation-prime-d-activite">caf.fr</a>, la question suivante est posée&nbsp;:
+
+    <blockquote>Vous (ou votre conjoint) êtes propriétaire de votre logement principal ou êtes logés gratuitement&nbsp;?</blockquote>
+
+    Dans votre situation, vous devez répondre&nbsp;:
+    <ul>
+      <li>«&nbsp;Non&nbsp;» si vous êtes bien
+        <strong ng-if="isProprietaireAvecPretEnCours">en train de rembourser le crédit pour votre logement principal.</strong>
+        <strong ng-if="isHebergeParticipeFrais">hébergé en participant aux frais du logement.</strong>
+      </li>
+      <li>«&nbsp;Oui&nbsp;» uniquement si
+      <span ng-if="isProprietaireAvecPretEnCours">vous n’avez <strong>pas de prêt pour votre habitation principale.</strong></span>
+      <span ng-if="isHebergeParticipeFrais">vous <strong>ne participez pas aux frais du logement.</strong></span>
+      </li>
+    </ul>
+  </p>
+
+  <div class="footer">
+     <a class="btn btn-default"
+      ng-click="closeModal()"
+      ui-sref="foyer.logement"
+      analytics-on="click"
+      analytics-name="Prime d’activité"
+      analytics-event="retour-logement"
+      >Retourner à la page «&nbsp;Logement&nbsp;»</a>
+     <a class="btn btn-default"
+      target="_blank"
+      rel="noopener"
+      analytics-on="click"
+      analytics-name="Prime d’activité"
+      analytics-event="simulation-caf"
+      href="http://www.caf.fr/allocataires/mes-services-en-ligne/estimer-vos-droits/simulation-prime-d-activite"
+      >Faire une nouvelle simulation sur caf.fr</a>
+     <a class="btn btn-default"
+      analytics-on="click"
+      analytics-name="Prime d’activité"
+      analytics-event="email"
+      mail-to="feedback@mes-aides.gouv.fr"
+      subject="[{{ situationId }}] Montants inattendus"
+      body="Bonjour,
+
+En effectuant une simulation sur mes-aides.gouv.fr, j'ai obtenu le résultat suivant :
+
+- {{ droit.montant | currency : ( droit.unit || '€' ) : 0 }} / mois pour la prestation « Prime d'activité ».
+
+Mais en effectuant la même simulation sur le site caf.fr j'obtiens le résultat suivant / la CAF a fini par m'attribuer le montant suivant :
+
+- XXX € / mois pour la prestation « Prime d'activité ».
+
+Vous pouvez me joindre par téléphone au XX XX XX XX XX (de préférence en semaine) pour une dizaine de minutes d'échange afin de comprendre d'où provient cet écart.
+
+Bonne journée,
+
+————
+ID : {{ situation._id }} (à conserver impérativement pour traitement de votre demande)
+————
+isProprietaireAvecPretEnCours: {{ isProprietaireAvecPretEnCours }}
+isHebergeParticipeFrais: {{ isHebergeParticipeFrais }}
+"
+      >Nous contacter</a>
+     <a class="btn btn-primary"
+      ng-click="closeModal()"
+      analytics-on="click"
+      analytics-name="Prime d’activité"
+      analytics-event="close"
+      >Fermer</a>
+  </div>
 </div>

--- a/app/views/partials/ppa-help.html
+++ b/app/views/partials/ppa-help.html
@@ -1,0 +1,22 @@
+<div style="padding: 20px;">
+
+  <h2 class="text-center"><i class="fa fa-info-circle"></i> Prime d'activité</h2>
+
+  <div ng-if="isProprietaireAvecPretEnCours || isHebergeParticipeFrais">
+    <p>
+    Vous avez indiqué être
+    <strong ng-if="isProprietaireAvecPretEnCours">propriétaire de votre logement principal avec un prêt en cours.</strong>
+    <strong ng-if="isHebergeParticipeFrais">hébergé en participant aux frais du logement.</strong>
+    </p>
+    <p>
+    Sur le simulateur de la Caf, vous devez répondre "Non" à la question "Vous (ou votre conjoint) êtes propriétaire de votre logement principal ou êtes logés gratuitement". Répondez "oui" uniquement si
+    <span ng-if="isProprietaireAvecPretEnCours">vous n’avez <strong>aucun prêt pour votre habitation principale.</strong></span>
+    <span ng-if="isHebergeParticipeFrais">vous <strong>ne participez pas aux frais du logement.</strong></span>
+    </p>
+  </div>
+
+  <p class="text-center">
+    <a href ng-click="closeModal()">Fermer</a>
+  </p>
+
+</div>


### PR DESCRIPTION
Fixes #1192

Pas du tout définitif niveau design etc...
En gros, le texte de la fenêtre est dynamique en fonction de la situation.

Ce serait peut-être encore mieux de rajouter des screenshots du simulateur de la Caf peut-être ?

<img width="726" alt="Capture d’écran 2019-04-15 à 15 25 47" src="https://user-images.githubusercontent.com/1162230/56136457-1e053600-5f93-11e9-90a5-50d52c1e58a9.png">

<img width="609" alt="Capture d’écran 2019-04-10 à 17 58 11" src="https://user-images.githubusercontent.com/1162230/55894795-1fadb300-5bbb-11e9-99e1-48ca4bf4fb7b.png">

<img width="609" alt="Capture d’écran 2019-04-10 à 18 04 00" src="https://user-images.githubusercontent.com/1162230/55894800-24726700-5bbb-11e9-8e63-7b5eb22ee246.png">
