### PR TITLE
Revert "Étend à 3 ans la période à zéro pour les prestations"

### DIFF
--- a/backend/lib/openfisca/mapping/common.js
+++ b/backend/lib/openfisca/mapping/common.js
@@ -36,9 +36,6 @@ exports.getPeriods = function (dateDeValeur) {
         last12Months: _.map(_.range(1, 12 + 1), function(monthIndex) {
             return dateDeValeur.clone().subtract(monthIndex, 'months').format('YYYY-MM');
         }),
-        last3YearsMonths: _.map(_.range(1, 3 * 12 + 1), function(monthIndex) {
-            return dateDeValeur.clone().subtract(monthIndex, 'months').format('YYYY-MM');
-        }),
         lastYear: dateDeValeur.clone().subtract(1, 'years').format('YYYY'),
         fiscalYear: dateDeValeur.clone().subtract(2, 'years').format('YYYY'),
         // 12-element array of the 12 months in the année fiscale de référence

--- a/backend/lib/openfisca/mapping/index.js
+++ b/backend/lib/openfisca/mapping/index.js
@@ -137,7 +137,7 @@ exports.buildOpenFiscaRequest = function(sourceSituation) {
     propertyMove.movePropertyValuesToGroupEntity(testCase);
 
     var periods = common.getPeriods(situation.dateDeValeur);
-    setNonInjectedPrestations(testCase, _.difference(periods.last3YearsMonths, periods.last3Months), 0);
+    setNonInjectedPrestations(testCase, _.difference(periods.last12Months, periods.last3Months), 0);
     last3MonthsDuplication(testCase, situation.dateDeValeur);
     giveValueToRequestedVariables(testCase, periods.thisMonth, null);
 


### PR DESCRIPTION
This reverts commit 14d698c14d73575b1e2d098a1f1ec6ae9167898f.

#1216 diminue déjà le temps de calcul.
#1213 générait des payloads trop gros pour être échangés sur le réseau.