### PR TITLE
Met à jour la version d'OpenFisca France

### DIFF
--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,5 +1,5 @@
 gunicorn>=19.1.1
-Openfisca-France==43.1.0
+Openfisca-France==47.1.0
 Openfisca-Core[web-api]==34.2.5
 git+https://github.com/betagouv/openfisca-france-local.git@6e29ce7#egg=openfisca-France-Local
 git+https://github.com/betagouv/openfisca-paris.git@91a97e8#egg=openfisca-paris

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,7 +1,7 @@
 gunicorn>=19.1.1
 Openfisca-France==47.1.0
 Openfisca-Core[web-api]==34.2.5
-git+https://github.com/betagouv/openfisca-france-local.git@6e29ce7#egg=openfisca-France-Local
+git+https://github.com/betagouv/openfisca-france-local.git@4c86e0c#egg=openfisca-France-Local
 git+https://github.com/betagouv/openfisca-paris.git@91a97e8#egg=openfisca-paris
 git+https://github.com/betagouv/openfisca-brestmetropole.git@8fb7260#egg=openfisca-BrestMetropole
 git+https://github.com/betagouv/openfisca-rennesmetropole.git@737328e#egg=openfisca-RennesMetropole

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -3,5 +3,5 @@ Openfisca-France==47.1.0
 Openfisca-Core[web-api]==34.2.5
 git+https://github.com/betagouv/openfisca-france-local.git@6e29ce7#egg=openfisca-France-Local
 git+https://github.com/betagouv/openfisca-paris.git@91a97e8#egg=openfisca-paris
-git+https://github.com/betagouv/openfisca-brestmetropole.git@f2b7aaa#egg=openfisca-BrestMetropole
-git+https://github.com/betagouv/openfisca-rennesmetropole.git@e98791d#egg=openfisca-RennesMetropole
+git+https://github.com/betagouv/openfisca-brestmetropole.git@8fb7260#egg=openfisca-BrestMetropole
+git+https://github.com/betagouv/openfisca-rennesmetropole.git@737328e#egg=openfisca-RennesMetropole

--- a/test/backend/openfisca/test.js
+++ b/test/backend/openfisca/test.js
@@ -69,7 +69,7 @@ function runOpenFiscaTest(yaml, extension) {
     var tmpobj = tmp.fileSync({postfix: '.yaml'});
     return fs.writeFileAsync(tmpobj.fd, yaml, 'utf8')
         .then(function() {
-            var args = extension ? ['test', tmpobj.name, '-e', extension] : ['test', tmpobj.name];
+            var args = extension ? ['test', tmpobj.name, '--extensions', extension] : ['test', tmpobj.name];
 
             return run_cmd('openfisca', args);
         });

--- a/test/backend/openfisca/test.js
+++ b/test/backend/openfisca/test.js
@@ -69,9 +69,9 @@ function runOpenFiscaTest(yaml, extension) {
     var tmpobj = tmp.fileSync({postfix: '.yaml'});
     return fs.writeFileAsync(tmpobj.fd, yaml, 'utf8')
         .then(function() {
-            var args = extension ? [tmpobj.name, '--extensions', extension] : [tmpobj.name];
+            var args = extension ? ['test', tmpobj.name, '-e', extension] : ['test', tmpobj.name];
 
-            return run_cmd('openfisca-run-test', args);
+            return run_cmd('openfisca', args);
         });
 }
 


### PR DESCRIPTION
Suite au merge de openfisca/openfisca-france#1347, la variable `garantie_jeunes` est dans OpenFisca France.

À merger avant : 
- betagouv/openfisca-rennesmetropole#28
- betagouv/openfisca-brestmetropole#22
- betagouv/openfisca-france-local#41
- betagouv/openfisca-paris#94

Ça prend également en compte les renommages de variables pour certaines prestations de la Ville de Paris
- betagouv/openfisca-paris#87
- betagouv/openfisca-paris#88