### PR TITLE
Corrige l'affichage du bloc des ressources dans le récapitulatif

### DIFF
--- a/app/js/controllers/foyer/recapSituation.js
+++ b/app/js/controllers/foyer/recapSituation.js
@@ -28,15 +28,10 @@ angular.module('ddsCommon').controller('RecapSituationCtrl', function($scope, $s
             }, {});
     }
 
-    function prepareRecapRessources() {
+    function buildRecapRessources() {
         $scope.individusSorted = SituationService.getIndividusSortedParentsFirst($scope.situation);
         $scope.ressourcesByIndividu = $scope.individusSorted.map(getRessources);
         $scope.haveRessourcesDeclared = _.some($scope.ressourcesByIndividu, _.negate(_.isEmpty));
-    }
-
-    function buildRecapRessources() {
-        $scope.ressourcesCaptured = true;
-        prepareRecapRessources();
     }
 
     function buildRecapPatrimoine () {
@@ -118,8 +113,7 @@ angular.module('ddsCommon').controller('RecapSituationCtrl', function($scope, $s
         if ($scope.situation.menage && $scope.situation.menage.statut_occupation_logement) {
             buildRecapLogement();
         }
-        prepareRecapRessources();
-        $scope.ressourcesCaptured = $scope.haveRessourcesDeclared || Boolean($scope.situation._id);
+        buildRecapRessources();
         if ($scope.ressourcesYearMoins2Captured) {
             buildYm2Recap();
         }

--- a/app/js/services/situationService.js
+++ b/app/js/services/situationService.js
@@ -2,7 +2,7 @@
 
 var DATE_FIELDS = ['date_naissance', 'date_arret_de_travail', 'date_debut_chomage'];
 
-angular.module('ddsCommon').factory('SituationService', function($http, $sessionStorage, categoriesRnc, patrimoineTypes, RessourceService) {
+angular.module('ddsCommon').factory('SituationService', function($http, $sessionStorage, categoriesRnc, patrimoineTypes) {
     var situation;
 
     /*
@@ -36,8 +36,6 @@ angular.module('ddsCommon').factory('SituationService', function($http, $session
                 individu[dateField] = moment(new Date(individu[dateField]));
             }
         });
-
-        individu.hasRessources = ! _.isEmpty(RessourceService.extractIndividuSelectedRessourceTypes(individu));
     }
 
     function adaptPersistedSituation(situation) {

--- a/app/views/partials/foyer/recap-situation.html
+++ b/app/views/partials/foyer/recap-situation.html
@@ -60,7 +60,7 @@
           </div>
         </div>
       </uib-accordion>
-      <div ng-if="! haveRessourcesDeclared">
+      <div ng-if="ressourcesByIndividu[$index] | isEmpty">
         <em class="small">Aucune ressource déclarée</em>
       </div>
     </div>

--- a/backend/lib/openfisca/mapping/individu/index.js
+++ b/backend/lib/openfisca/mapping/individu/index.js
@@ -91,6 +91,7 @@ function buildOpenFiscaIndividu(mesAidesIndividu, situation) {
     // Variables stored to properly restore UI
     var propertiesToDelete = [
         'firstName', // for kids
+        'hasRessources',
         'nationalite',
         'role',
         'specificSituations',

--- a/backend/models/situation.js
+++ b/backend/models/situation.js
@@ -55,6 +55,7 @@ var individuDef = Object.assign({
     garde_alternee: Boolean,
     gir: { type: String, default: 'non_defini' },
     habite_chez_parents: Boolean,
+    hasRessources: Boolean,
     nationalite: { type: String },
     role: { type: String, enum: ['demandeur', 'conjoint', 'enfant'] },
     scolarite: { type: String, enum: ['inconnue', 'college', 'lycee'] },

--- a/test/spec/controllers/foyer/recapSituation.js
+++ b/test/spec/controllers/foyer/recapSituation.js
@@ -25,20 +25,6 @@ describe('Controller: RecapSituationCtrl', function() {
         });
     };
 
-    describe('ressourcesUpdated event', function() {
-        it('should set the ressourcesCaptured value to true', function() {
-            // given
-            scope.situation.dateDeValeur = '2013-04-05';
-            initController();
-
-            // when
-            scope.$broadcast('ressourcesUpdated');
-
-            // then
-            expect(scope.ressourcesCaptured).toBeTruthy();
-        });
-    });
-
     describe('shouldDisplayPersonRessourcesRecap', function() {
         it('be false for demandeur without hasRessources', function() {
             // given


### PR DESCRIPTION
* Le bloc «Ressources» apparaissait trop tôt dans la simulation

Debug : Cela était dû à l'utilisation de [`restore_local`](https://github.com/betagouv/mes-aides-ui/blob/master/app/js/app.js#L405) dans les transitions.