### PR TITLE
Met à jour les dépendances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,81 +1597,6 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
-    "archiver": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
-      "integrity": "sha1-W53bn17hzu8hy487Ag5iQOy0MVw=",
-      "dev": true,
-      "requires": {
-        "async": "~0.9.0",
-        "buffer-crc32": "~0.2.1",
-        "glob": "~4.3.0",
-        "lazystream": "~0.1.0",
-        "lodash": "~3.2.0",
-        "readable-stream": "~1.0.26",
-        "tar-stream": "~1.1.0",
-        "zip-stream": "~0.5.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "dev": true
-        },
-        "glob": {
-          "version": "4.3.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-          "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-          "integrity": "sha1-S/UKMkP5rrC6xBpV09WZBnWkYvs=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
@@ -2256,41 +2181,6 @@
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
     },
-    "bl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~1.0.26"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -2412,15 +2302,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
-    },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x"
-      }
     },
     "bootstrap-sass": {
       "version": "3.4.1",
@@ -2622,12 +2503,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "dev": true
-    },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-equal-constant-time": {
@@ -3062,50 +2937,6 @@
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
-    "compress-commons": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
-      "integrity": "sha1-Qi2SdDDAGr0GzUVbbfwEy0z4ADw=",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.1",
-        "crc32-stream": "~0.3.1",
-        "node-int64": "~0.3.0",
-        "readable-stream": "~1.0.26"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "node-int64": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz",
-          "integrity": "sha1-LW5rLs5d6FiLQ9iNG8QbJs0fqE0=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "compressible": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
@@ -3460,42 +3291,6 @@
         }
       }
     },
-    "crc32-stream": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
-      "integrity": "sha1-c7wltF+sHbZjIjGnv86JJ+nwZVI=",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.1",
-        "readable-stream": "~1.0.24"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -3550,15 +3345,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.x.x"
-      }
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -3737,12 +3523,6 @@
       "requires": {
         "cssom": "0.3.x"
       }
-    },
-    "ctype": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
-      "dev": true
     },
     "currencyformatter.js": {
       "version": "2.2.0",
@@ -6320,9 +6100,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -6394,24 +6174,6 @@
       "dev": true,
       "requires": {
         "globule": "^1.0.0"
-      }
-    },
-    "generate-function": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
-      "requires": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -7000,18 +6762,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hawk": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-      "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-      "dev": true,
-      "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
-      }
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -7028,12 +6778,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -7755,25 +7499,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
-      "integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
-      "dev": true,
-      "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -7837,12 +7562,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-regex": {
@@ -8757,12 +8476,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
-    },
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -8949,41 +8662,6 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
-    },
-    "lazystream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
-      "integrity": "sha1-GyXWPHcqTCDwpe0KnXf0hLbhaSA=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~1.0.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
     },
     "lcid": {
       "version": "1.0.0",
@@ -9430,15 +9108,6 @@
         "uc.micro": "^1.0.5"
       }
     },
-    "mattisg.configloader": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/mattisg.configloader/-/mattisg.configloader-0.2.1.tgz",
-      "integrity": "sha1-hRObSrOqlo5gJzinmyeW7YGrIRQ=",
-      "dev": true,
-      "requires": {
-        "mootools": "1.4"
-      }
-    },
     "md5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
@@ -9656,9 +9325,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -9928,12 +9597,6 @@
           }
         }
       }
-    },
-    "mootools": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/mootools/-/mootools-1.4.5.tgz",
-      "integrity": "sha1-Ek7Z2uBvKn+LaU4Xjp4BRtcywxQ=",
-      "dev": true
     },
     "morgan": {
       "version": "1.9.1",
@@ -11618,12 +11281,6 @@
         }
       }
     },
-    "q": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
-      "dev": true
-    },
     "qjobs": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
@@ -12602,9 +12259,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -12887,15 +12544,6 @@
             "is-buffer": "^1.1.5"
           }
         }
-      }
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x"
       }
     },
     "socket.io": {
@@ -13489,12 +13137,6 @@
       "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
       "dev": true
     },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -13618,52 +13260,14 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
-      }
-    },
-    "tar-stream": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
-      "integrity": "sha1-vpIYwTDCACnhB7D5Z/sj3gV50Tw=",
-      "dev": true,
-      "requires": {
-        "bl": "^0.9.0",
-        "end-of-stream": "^1.0.0",
-        "readable-stream": "~1.0.33",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
       }
     },
     "terser": {
@@ -14203,38 +13807,15 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {
@@ -14489,12 +14070,6 @@
       "integrity": "sha512-JhjoMbCx3DG4GN/M/j06n1bVLeJPsZ7XelyCx8q87M9d5k3jwuWaY+a+09XBq1uOGQAW8QaWska66hOzXNKiQg==",
       "dev": true
     },
-    "vargs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
-      "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
-      "dev": true
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -14562,11 +14137,291 @@
           "dev": true,
           "optional": true
         },
+        "mattisg.configloader": {
+          "version": "0.2.0-alpha.2",
+          "resolved": "https://registry.npmjs.org/mattisg.configloader/-/mattisg.configloader-0.2.0-alpha.2.tgz",
+          "integrity": "sha1-bw7jHl6huztKG/z3f+lZZSfTSPw=",
+          "dev": true,
+          "requires": {
+            "mootools": "1.4"
+          }
+        },
+        "mootools": {
+          "version": "1.4.5-2",
+          "resolved": "https://registry.npmjs.org/mootools/-/mootools-1.4.5-2.tgz",
+          "integrity": "sha1-q4Pqq0SBiFm8pBqWJvf/8d6E7Lw=",
+          "dev": true
+        },
         "q": {
           "version": "0.9.7",
           "resolved": "http://registry.npmjs.org/q/-/q-0.9.7.tgz",
           "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U=",
           "dev": true
+        },
+        "wd": {
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/wd/-/wd-0.2.6.tgz",
+          "integrity": "sha1-ZR8r8MbEmVRrExfHXBbOyH3GGSE=",
+          "dev": true,
+          "requires": {
+            "archiver": "~0.4.10",
+            "async": "~0.2.9",
+            "lodash": "~1.3.1",
+            "q": "~0.9.7",
+            "request": "~2.21.0",
+            "underscore.string": "~2.3.3",
+            "vargs": "~0.1.0"
+          },
+          "dependencies": {
+            "archiver": {
+              "version": "0.4.10",
+              "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.4.10.tgz",
+              "integrity": "sha1-3w/qyPHRKV5ezrOiBVWQctIfR0c=",
+              "dev": true,
+              "requires": {
+                "iconv-lite": "~0.2.11",
+                "readable-stream": "~1.0.2"
+              },
+              "dependencies": {
+                "iconv-lite": {
+                  "version": "0.2.11",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+                  "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+                  "dev": true
+                },
+                "readable-stream": {
+                  "version": "1.0.17",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.17.tgz",
+                  "integrity": "sha1-y8KV/fOU36EiXSJdAua20PQJ/Us=",
+                  "dev": true
+                }
+              }
+            },
+            "async": {
+              "version": "0.2.9",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
+              "integrity": "sha1-32MGD789Myhqdqr21Vophtn/hhk=",
+              "dev": true
+            },
+            "lodash": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+              "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A=",
+              "dev": true
+            },
+            "request": {
+              "version": "2.21.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.21.0.tgz",
+              "integrity": "sha1-VyirnEXlqHyZ2szVMCmLZnOoaNc=",
+              "dev": true,
+              "requires": {
+                "aws-sign": "~0.3.0",
+                "cookie-jar": "~0.3.0",
+                "forever-agent": "~0.5.0",
+                "form-data": "0.0.8",
+                "hawk": "~0.13.0",
+                "http-signature": "~0.9.11",
+                "json-stringify-safe": "~4.0.0",
+                "mime": "~1.2.9",
+                "node-uuid": "~1.4.0",
+                "oauth-sign": "~0.3.0",
+                "qs": "~0.6.0",
+                "tunnel-agent": "~0.3.0"
+              },
+              "dependencies": {
+                "aws-sign": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz",
+                  "integrity": "sha1-PYHKabR0seFlGHKLUcJP8Lvtxuk=",
+                  "dev": true
+                },
+                "cookie-jar": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz",
+                  "integrity": "sha1-vJon1OK5fhhs1XyeIGPLmfpozMw=",
+                  "dev": true
+                },
+                "forever-agent": {
+                  "version": "0.5.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.0.tgz",
+                  "integrity": "sha1-DBZHp0868S12oHqZSQrefHJJyPA=",
+                  "dev": true
+                },
+                "form-data": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.8.tgz",
+                  "integrity": "sha1-CJDNEAXFzOzAudJKiAUskkQtDbU=",
+                  "dev": true,
+                  "requires": {
+                    "async": "~0.2.7",
+                    "combined-stream": "~0.0.4",
+                    "mime": "~1.2.2"
+                  },
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.4",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                      "integrity": "sha1-LRpDNH2+lRWkonlnMuW4hHOECyI=",
+                      "dev": true,
+                      "requires": {
+                        "delayed-stream": "0.0.5"
+                      },
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "0.13.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.13.1.tgz",
+                  "integrity": "sha1-NheViCH1gxHk1/beKR/KZitBLvQ=",
+                  "dev": true,
+                  "requires": {
+                    "boom": "0.4.x",
+                    "cryptiles": "0.2.x",
+                    "hoek": "0.8.x",
+                    "sntp": "0.2.x"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                      "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+                      "dev": true,
+                      "requires": {
+                        "hoek": "0.9.x"
+                      },
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                      "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+                      "dev": true,
+                      "requires": {
+                        "boom": "0.4.x"
+                      }
+                    },
+                    "hoek": {
+                      "version": "0.8.5",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.8.5.tgz",
+                      "integrity": "sha1-Hp/XcO9+vgJ0rfy1sIBqAlpeTp8=",
+                      "dev": true
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                      "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+                      "dev": true,
+                      "requires": {
+                        "hoek": "0.9.x"
+                      },
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.9.11",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.9.11.tgz",
+                  "integrity": "sha1-nognFFcjFeZ5Cl0KeVXv/x8Z5lM=",
+                  "dev": true,
+                  "requires": {
+                    "asn1": "0.1.11",
+                    "assert-plus": "0.1.2",
+                    "ctype": "0.5.2"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+                      "dev": true
+                    },
+                    "assert-plus": {
+                      "version": "0.1.2",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
+                      "integrity": "sha1-2T/9u2esVQd3m+MWp9ZRRkF77vg=",
+                      "dev": true
+                    },
+                    "ctype": {
+                      "version": "0.5.2",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
+                      "integrity": "sha1-/oCR1Gijc6Cwyf+Lv7NCXACXOh0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "4.0.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-4.0.0.tgz",
+                  "integrity": "sha1-d8JxqupUMC5o7+rMtWq78GqbGlQ=",
+                  "dev": true
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+                  "dev": true
+                },
+                "node-uuid": {
+                  "version": "1.4.1",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
+                  "integrity": "sha1-Oa71EOWImj3KnIlbUGxzquG6wEg=",
+                  "dev": true
+                },
+                "oauth-sign": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+                  "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
+                  "dev": true
+                },
+                "qs": {
+                  "version": "0.6.6",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+                  "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc=",
+                  "dev": true
+                },
+                "tunnel-agent": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
+                  "integrity": "sha1-rWgbaPUyGtKCfEz7G31d8s/pQu4=",
+                  "dev": true
+                }
+              }
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+              "dev": true
+            },
+            "vargs": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
+              "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
+              "dev": true
+            }
+          }
         },
         "winston": {
           "version": "0.6.2",
@@ -14647,218 +14502,6 @@
       "dev": true,
       "requires": {
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "wd": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/wd/-/wd-0.3.12.tgz",
-      "integrity": "sha1-P7Tx11n4yF3eU5PRczT/4D6bsyk=",
-      "dev": true,
-      "requires": {
-        "archiver": "~0.14.0",
-        "async": "~1.0.0",
-        "lodash": "~3.9.3",
-        "q": "~1.4.1",
-        "request": "~2.55.0",
-        "underscore.string": "~3.0.3",
-        "vargs": "~0.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "asn1": {
-          "version": "0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-          "dev": true
-        },
-        "async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-          "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "0.0.5"
-          }
-        },
-        "delayed-stream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-          "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
-          "dev": true,
-          "requires": {
-            "async": "~0.9.0",
-            "combined-stream": "~0.0.4",
-            "mime-types": "~2.0.3"
-          },
-          "dependencies": {
-            "async": {
-              "version": "0.9.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-              "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-              "dev": true
-            }
-          }
-        },
-        "har-validator": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-          "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
-          "dev": true,
-          "requires": {
-            "bluebird": "^2.9.30",
-            "chalk": "^1.0.0",
-            "commander": "^2.8.1",
-            "is-my-json-valid": "^2.12.0"
-          }
-        },
-        "http-signature": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-          "dev": true,
-          "requires": {
-            "asn1": "0.1.11",
-            "assert-plus": "^0.1.5",
-            "ctype": "0.5.3"
-          }
-        },
-        "lodash": {
-          "version": "3.9.3",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
-          "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-          "dev": true,
-          "requires": {
-            "mime-db": "~1.12.0"
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-          "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM=",
-          "dev": true
-        },
-        "qs": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-          "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.55.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
-          "integrity": "sha1-11wc32eddrsQD5v/4f5VG1wk6T0=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.5.0",
-            "bl": "~0.9.0",
-            "caseless": "~0.9.0",
-            "combined-stream": "~0.0.5",
-            "forever-agent": "~0.6.0",
-            "form-data": "~0.2.0",
-            "har-validator": "^1.4.0",
-            "hawk": "~2.3.0",
-            "http-signature": "~0.10.0",
-            "isstream": "~0.1.1",
-            "json-stringify-safe": "~5.0.0",
-            "mime-types": "~2.0.1",
-            "node-uuid": "~1.4.0",
-            "oauth-sign": "~0.6.0",
-            "qs": "~2.4.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": ">=0.12.0",
-            "tunnel-agent": "~0.4.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
-          "integrity": "sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI=",
-          "dev": true
-        }
       }
     },
     "webidl-conversions": {
@@ -15711,49 +15354,6 @@
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
-    },
-    "zip-stream": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
-      "integrity": "sha1-Mty8UG0Nq00hNyYlvX66rDwv/1Y=",
-      "dev": true,
-      "requires": {
-        "compress-commons": "~0.2.0",
-        "lodash": "~3.2.0",
-        "readable-stream": "~1.0.26"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-          "integrity": "sha1-S/UKMkP5rrC6xBpV09WZBnWkYvs=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
```
➜  mes-aides-ui git:(upgrade) ✗ npm audit fix
npm WARN read-shrinkwrap This version of npm is compatible with lockfileVersion@1, but npm-shrinkwrap.json was generated for lockfileVersion@0. I'll try to do my best with it!
npm WARN deprecated hoek@0.8.5: The major version is no longer supported. Please update to 4.x or newer
npm WARN deprecated hoek@0.9.1: The major version is no longer supported. Please update to 4.x or newer
npm WARN deprecated node-uuid@1.4.1: Use uuid module instead
added 31 packages from 53 contributors, removed 115 packages, updated 5 packages and moved 3 packages in 21.017s
fixed 12960 of 12988 vulnerabilities in 886537 scanned packages
  25 vulnerabilities required manual review and could not be updated
  1 package update for 3 vulns involved breaking changes
  (use `npm audit fix --force` to install breaking changes; or refer to `npm audit` for steps to fix these manually)
```