### PR TITLE
Invite tout le monde à saisir les ressources fiscales

### DIFF
--- a/app/js/services/resultatService.js
+++ b/app/js/services/resultatService.js
@@ -7,14 +7,19 @@ angular.module('ddsApp').service('ResultatService', function($http, $rootScope) 
 
     var _loading = false;
 
-    function simulate(situation, showPrivate) {
-        setLoading(true);
+    function fetch(situation, showPrivate) {
         return $http.get('api/situations/' + situation._id + '/openfisca-response')
             .then(function(OpenfiscaResponse) {
                 return OpenfiscaResponse.data;
             }).then(function(openfiscaResponse) {
                 return computeAides(situation, openfiscaResponse, showPrivate);
-            }).finally(function() {
+            });
+    }
+
+    function simulate(situation, showPrivate) {
+        setLoading(true);
+        return fetch(situation, showPrivate)
+            .finally(function() {
                 setLoading(false);
             });
     }

--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -42,11 +42,6 @@ Erreur : {{ encodedError }}
 
 <div ng-show="! error && ! warning && ! awaitingResults">
 
-  <div class="frame-resultats" ng-show="(droits | isEmpty) && ! ressourcesYearMoins2Captured">
-      <h2>Juste une dernière étape…</h2>
-      <ym2-ressources-call-to-action></ym2-ressources-call-to-action>
-  </div>
-
   <div ng-if="! (droits | isEmpty)">
     <p>
       D'après la situation que vous avez décrite, vous êtes a priori éligible à ces aides.
@@ -68,6 +63,11 @@ Erreur : {{ encodedError }}
   <div class="frame-resultats" ng-show="(droits | isEmpty) && ressourcesYearMoins2Captured">
       <h2>Votre simulation n'a pas permis de découvrir de nouveaux droits.</h2>
       <p>Si vous êtes dans une situation difficile, d'<a ui-sref="sos">autres solutions existent</a>.</p>
+  </div>
+
+  <div class="frame-resultats" ng-show="! ressourcesYearMoins2Captured">
+    <h2 ng-show="(droits | isEmpty)">Juste une dernière étape…</h2>
+    <ym2-ressources-call-to-action></ym2-ressources-call-to-action>
   </div>
 
   <offline-result situation="situation"></offline-result>


### PR DESCRIPTION
![Capture d’écran de 2019-08-07 08-38-14](https://user-images.githubusercontent.com/1410356/62601495-c861ea00-b8f1-11e9-8da5-067cc89883ad.png)

Les personnes qui ont des ressources dans la moyenne supérieure de nos utilisateurs et à qui on affiche que le livret d'épargne populaire ne sont pas invité principalement à saisir leurs ressources sur l'année fiscale.

Les ressources sur cette année sont considérées équivalentes à celles des 12 derniers mois. Cette hypothèse n'étant pas toujours valable il faut permettre aux utilisateurs de saisir les vraies informations.


Suite à un email qui ressemble à :

>  Bonjour,
> 
> En effectuant une simulation sur mes-aides.gouv.fr, j'ai obtenu le résultat suivant :
> 
> - 0 € / mois pour la prestation aide au logement APL .
> 
> Mais en effectuant la même simulation sur le site caf, j'ai obtenu le résultat suivant :
> 
> - 131 € / mois pour la prestation aide au logement APL
> 
> Bonne journée,