### PR TITLE
Fixe un glitch visuel.

### DIFF
--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -65,7 +65,7 @@ Erreur : {{ encodedError }}
       <p>Si vous êtes dans une situation difficile, d'<a ui-sref="sos">autres solutions existent</a>.</p>
   </div>
 
-  <div class="frame-resultats" ng-show="! ressourcesYearMoins2Captured">
+  <div class="frame-resultats" ng-show="false === ressourcesYearMoins2Captured">
     <h2 ng-show="(droits | isEmpty)">Juste une dernière étape…</h2>
     <ym2-ressources-call-to-action></ym2-ressources-call-to-action>
   </div>

--- a/app/views/partials/resultat.html
+++ b/app/views/partials/resultat.html
@@ -65,7 +65,7 @@ Erreur : {{ encodedError }}
       <p>Si vous êtes dans une situation difficile, d'<a ui-sref="sos">autres solutions existent</a>.</p>
   </div>
 
-  <div class="frame-resultats" ng-show="false === ressourcesYearMoins2Captured">
+  <div class="frame-resultats" ng-show="ressourcesYearMoins2Captured === false">
     <h2 ng-show="(droits | isEmpty)">Juste une dernière étape…</h2>
     <ym2-ressources-call-to-action></ym2-ressources-call-to-action>
   </div>


### PR DESCRIPTION
Sur la page de résultats, certains blocs sont affichés AVANT que le calcul ait eu lieu. 

Pour le bloc des ressources fiscales, c'est parce que `ressourcesYearMoins2Captured` vaut `undefined` au départ, qui est _falsy_. Ce petit changement s'assure que `ressourcesYearMoins2Captured` a bien été évalué. 

Pour l'autre bloc, c'est fixé dans #1318

![glitch-ma](https://user-images.githubusercontent.com/1162230/62610089-3b279100-b903-11e9-964c-f9a91df8a5c9.gif)
