### PR TITLE
Supprime un focus qui n'apporte rien.

### DIFF
--- a/app/js/controllers/homepage.js
+++ b/app/js/controllers/homepage.js
@@ -32,7 +32,5 @@ angular.module('ddsApp').controller('HomepageCtrl', function($scope, $state, $se
             $sessionStorage.phishingNoticationDone = true;
             $state.go('hameconnage');
         }
-    } else {
-        document.querySelector('#valueProposition a').focus();
     }
 });


### PR DESCRIPTION
Pour tenter de fixer l'issue ["SyntaxError: The string did not match the expected pattern."](https://sentry.data.gouv.fr/betagouvfr/mes-aides-ui/issues/659376)

Je n'arrive pas à reproduire le bug (se produit sous MacOSX + Safari quand on vient d'Ameli.fr)
J'arrive à reproduire l'erreur en tapant un sélecteur CSS invalide dans la console de Safari.

Du coup, j'ai cherché un peu tous les sélecteur CSS qui pourraient être incriminés dans l'affaire. 
Et je suis tombé sur celui-ci, qui me semble ne pas apporter grand-chose, et qui de toutes façons ne marche pas (`document.querySelector('#valueProposition a').focus()` ne fait rien, l'élément ne prend pas le focus).