### PR TITLE
Utilise smooth-scroll sans les poylfills.

### DIFF
--- a/app/js/services/scrollService.js
+++ b/app/js/services/scrollService.js
@@ -1,5 +1,7 @@
 'use strict';
-var SmoothScroll = require('smooth-scroll');
+
+// As we are using Babel, make sure to require smooth-scroll *WITHOUT* polyfills
+var SmoothScroll = require('smooth-scroll/dist/smooth-scroll.js');
 
 angular.module('ddsCommon').factory('ScrollService', function() {
     var scroll = new SmoothScroll();


### PR DESCRIPTION
Pour tenter de fixer l'issue [undefined errorz.prototype._promiseRejectionHandler(vendor)](https://sentry.data.gouv.fr/betagouvfr/mes-aides-ui/issues/623918/)

L'issue se produit quand on clique sur "Comment l'obtenir ?" sur la page de résultat. 

Par défaut, `require('smooth-scroll')` inclut des polyfills. Comme on utilise Babel, ce n'est pas la peine. 

> If you're including your own polyfills or don't want to enable this feature for older browsers, use the standalone version. Otherwise, use the version with polyfills.