### PR TITLE
Revert "Utilise smooth-scroll sans les poylfills."

### DIFF
--- a/app/js/services/scrollService.js
+++ b/app/js/services/scrollService.js
@@ -1,7 +1,5 @@
 'use strict';
-
-// As we are using Babel, make sure to require smooth-scroll *WITHOUT* polyfills
-var SmoothScroll = require('smooth-scroll/dist/smooth-scroll.js');
+var SmoothScroll = require('smooth-scroll');
 
 angular.module('ddsCommon').factory('ScrollService', function() {
     var scroll = new SmoothScroll();


### PR DESCRIPTION
This reverts commit a1a5a4969ad0d75a9f1fb9dac4c22b57a7226398.

Je suis débile, Babel n'inclut pas ces polyfills 😖 

https://dev.to/mzanggl/what-babel-polyfill-doesnt-include-31bi
https://github.com/zloirock/core-js/issues/317#issuecomment-314691446