### PR TITLE
Déploie rapidement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,8 +229,6 @@ workflows:
             - build
             - install_openfisca
       - deploy:
-          requires:
-            - test_e2e
           filters:
             branches:
               only: vue


### PR DESCRIPTION
* Les tests n'ont pas besoin d'être relancés sur vue