### PR TITLE
Mutualise InputDate et InputMonth 

### DIFF
--- a/src/components/ASSQuestions.vue
+++ b/src/components/ASSQuestions.vue
@@ -3,9 +3,8 @@
     <div class="form__group">
       <label>
         Quand s’est terminé {{ individu.role == 'demandeur' ? 'votre' : 'son' }} dernier contrat de travail ? (MM/AAAA)
-        <MonthInput v-model="individu.date_debut_chomage" />
+        <InputMonth v-model="individu.date_debut_chomage" />
       </label>
-      
       <div>
         {{ individu.role == 'demandeur' ? 'Si vous n\'avez' : 'S\'il ou elle n\'a' }} jamais eu de contrat de travail, laissez ce champ vide.
       </div>
@@ -26,13 +25,13 @@
 <script>
 import moment from 'moment'
 
-import MonthInput from '@/components/MonthInput'
 import YesNoQuestion from '@/components/YesNoQuestion'
+import InputMonth from "@/components/InputMonth";
 
 export default {
   name: 'ASSQuestions',
   components: {
-    MonthInput,
+    InputMonth,
     YesNoQuestion
   },
   props: {

--- a/src/components/IndividuForm.vue
+++ b/src/components/IndividuForm.vue
@@ -27,7 +27,7 @@
     </div>
 
     <NationalityChoice class="form__group" v-model="individu.nationalite" />
-    
+
     <div class="form__group" v-if="captureOutOfFranceQuestions">
       <label>
         <input type="checkbox" v-model="satisfyResidentialDurationPrerequisite">

--- a/src/components/InputDate.vue
+++ b/src/components/InputDate.vue
@@ -64,9 +64,11 @@ export default {
     }
   },
   data: function() {
+    const captureFullDate = (this.dateType === "date")
+
     return {
-      currentState: this.value ? 0 : ((this.dateType === "date") ? { element: 'day', length: 0 } : { element: 'day', length: 2 }),
-      day: (this.dateType === "date") ? this.value && moment(this.value).format('DD') : "01",
+      currentState: this.value ? 0 : (captureFullDate ? { element: 'day', length: 0 } : { element: 'day', length: 2 }),
+      day: captureFullDate ? this.value && moment(this.value).format('DD') : "01",
       month: this.value && moment(this.value).format('MM'),
       year: this.value && moment(this.value).format('YYYY'),
     }

--- a/src/components/InputDate.vue
+++ b/src/components/InputDate.vue
@@ -65,7 +65,7 @@ export default {
   },
   data: function() {
     return {
-      currentState: this.value ? 0 : { element: 'day', length: 0 },
+      currentState: this.value ? 0 : ((this.dateType === "date") ? { element: 'day', length: 0 } : { element: 'day', length: 2 }),
       day: (this.dateType === "date") ? this.value && moment(this.value).format('DD') : "01",
       month: this.value && moment(this.value).format('MM'),
       year: this.value && moment(this.value).format('YYYY'),

--- a/src/components/InputDate.vue
+++ b/src/components/InputDate.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <input
+      v-if="showDay"
       type="number"
       autofocus
       v-bind:id="firstId"
@@ -56,11 +57,16 @@ export default {
   props: {
     id: String,
     value: Date,
+    //dateType should be "date" for a DD-MM-YYY date input and "month" for MM-YYYY
+    dateType: {
+      type: String,
+      default: "date"
+    }
   },
   data: function() {
     return {
       currentState: this.value ? 0 : { element: 'day', length: 0 },
-      day: this.value && moment(this.value).format('DD'),
+      day: (this.dateType === "date") ? this.value && moment(this.value).format('DD') : "01",
       month: this.value && moment(this.value).format('MM'),
       year: this.value && moment(this.value).format('YYYY'),
     }
@@ -75,6 +81,9 @@ export default {
     firstId: function() {
       const uniqueFieldName = 'id.' + Math.random().toString(36).slice(2)
       return this.id || uniqueFieldName
+    },
+    showDay: function() {
+      return this.dateType === "date"
     }
   },
   methods: {

--- a/src/components/InputMonth.vue
+++ b/src/components/InputMonth.vue
@@ -1,0 +1,27 @@
+<template>
+    <InputDate v-model="date" v-on:input="$emit('input', date)" dateType="month"/>
+</template>
+
+<script>
+    //This component is a simple sugar for InputDate.
+  import InputDate from '@/components/InputDate'
+
+  export default {
+    name: "InputMonth",
+    props: {
+      value: Date
+    },
+    components: {
+      InputDate
+    },
+    data: function() {
+      let date
+      return { date: date }
+    },
+    methods: {
+      updateDate: function(date) {
+        this.$emit('input', date);
+      }
+    }
+  }
+</script>

--- a/src/components/InputMonth.vue
+++ b/src/components/InputMonth.vue
@@ -15,7 +15,7 @@
       InputDate
     },
     data: function() {
-      let date
+      let date = this.value
       return { date: date }
     },
     methods: {


### PR DESCRIPTION
Fixes #1382

Suite au sprint open source, fin de ce que j'avais initié : 
* MonthInput => InputMonth (pour cohérence du nommage)
* MonthInput ne fait qu'utiliser InputDate avec un option spécifique, rendu plus générique. 