### PR TITLE
Corrige l'artefact au clic des boutons

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -9,6 +9,12 @@ $screen-md-min:     992px;
 $screen-sm-max:     $screen-md-min - 1;
 $screen-xs-max:     768px-1;
 
+button.button:active,
+button.button:focus {
+    width: 100%;
+    margin-right: 0;
+}
+
 .button.warning-light {
   color: #454545;
 }


### PR DESCRIPTION
Sur les petits écrans, les boutons « bougent » en passant de toute la largeur à une partie seulement ce qui peut surprendre les usagers mais surtout qui, dans certains cas, ne déclenche pas l'évènement de clic.

Lié à https://github.com/etalab/template.data.gouv.fr/issues/145