### PR TITLE
Supprime les fieldsets bloquants sur iPhone

### DIFF
--- a/src/components/InputDate.vue
+++ b/src/components/InputDate.vue
@@ -1,5 +1,5 @@
 <template>
-  <fieldset>
+  <div>
     <input
       type="number"
       autofocus
@@ -30,7 +30,7 @@
       v-select-on-click
       min="1900"
       max="2020">
-  </fieldset>
+  </div>
 </template>
 
 <script>

--- a/src/components/Ressource/AutoEntreprise.vue
+++ b/src/components/Ressource/AutoEntreprise.vue
@@ -15,7 +15,7 @@
         v-model="ressource.amounts[$store.state.dates.lastYear.id]">
     </label>
 
-    <fieldset class="form__group">
+    <div class="form__group">
       <label>
         Chiffre d'affaires pour {{ $store.state.dates.thisMonth.label | capitalize }}
         <input
@@ -28,7 +28,7 @@
           type="number" v-select-on-click
           v-model="ressource.amounts[month.id]">
       </label>
-    </fieldset>
+    </div>
   </div>
 </template>
 

--- a/src/components/Ressource/Montants.vue
+++ b/src/components/Ressource/Montants.vue
@@ -1,5 +1,5 @@
 <template>
-  <fieldset class="form__group" v-bind:key="type.meta.id">
+  <div class="form__group" v-bind:key="type.meta.id">
     <legend><h2 v-if="!withoutHeader">{{ type.meta.label }}</h2></legend>
     <YesNoQuestion class="form__group" v-model="singleValue">
       <span v-html="getQuestionLabel(individu, type.meta, $store.state.dates.twelveMonthsAgo.label)" />
@@ -22,7 +22,7 @@
         </label>
       </div>
     </div>
-  </fieldset>
+  </div>
 </template>
 
 <script>

--- a/src/components/Ressource/Types.vue
+++ b/src/components/Ressource/Types.vue
@@ -5,13 +5,13 @@
       Sélectionnez les types de ressources perçues <strong>depuis {{ $store.state.dates.twelveMonthsAgo.label }}</strong>,
       vous pourrez ensuite saisir les montants.
     </p>
-      <fieldset class="form__group" v-for="category in categories" v-bind:key="category.id">
+      <div class="form__group" v-for="category in categories" v-bind:key="category.id">
         <h2>{{ category.label }}</h2>
         <label v-for="type in sort(typesByCategories[category.id])" v-bind:key="type.id">
           <input type="checkbox" v-model="selectedTypes[type.id]"/>
           {{ type.label }}
         </label>
-      </fieldset>
+      </div>
     <div class="form__group">{{ countLabel }}</div>
     <div class="text-right">
       <button type="submit" class="button large" v-on:click.prevent="next">Valider</button>


### PR DESCRIPTION
La façon dont les fieldsets sont gérés sur iPhone semble bloquer les utilisateurs.

Lors d'un clic, le focus semble toujours donné au premier input.

Ceci est un hot-fix. L'accessibilité est peut-être dégradée avec cette modification.

Le taux de conversion de la page demandeur est passé de 84% à 68%. Pas le temps de faire de l'AB testing mais espérons que demain les stats soient meilleurs...