### PR TITLE
Répare la génération de liens vers le serveur

### DIFF
--- a/configure.js
+++ b/configure.js
@@ -36,6 +36,8 @@ module.exports = function(app) {
       }
   }
 
+  app.set('trust proxy', true)
+
   app.route('/foyer/resultat').post(function(req, res) {
       var html = Buffer.from(req.body.base64, 'base64').toString('utf-8');
 


### PR DESCRIPTION
* Les liens de représentation pour les téléservices reposent sur req.protocol
* Les informations envoyées par le proxy doivent être rendues accessibles
cf. http://expressjs.com/en/5x/api.html\#req.protocol
et http://expressjs.com/en/5x/api.html\#trust.proxy.options.table