### PR TITLE
Indique le format attendu pour les dates

### DIFF
--- a/src/components/IndividuForm.vue
+++ b/src/components/IndividuForm.vue
@@ -372,7 +372,9 @@ export default {
       }
 
       this.$v.$touch()
-      if (! this.$v.$invalid) {
+      if (this.$v.$invalid) {
+        this.$matomo && this.$matomo.trackEvent('General', 'Invalid form', this.$route.fullPath)
+      } else {
         this.$emit('input', this.individu)
       }
     },

--- a/src/components/InputDate.vue
+++ b/src/components/InputDate.vue
@@ -8,7 +8,7 @@
         ref="day"
         aria-label="Jour"
         v-model="day"
-        placeholder="23"
+        placeholder="JJ"
         v-select-on-click
         min=1
         max=31 />
@@ -19,7 +19,7 @@
       ref="month"
       aria-label="Mois"
       v-model="month"
-      placeholder="02"
+      placeholder="MM"
       v-select-on-click
       min=1
       max=12 />
@@ -29,7 +29,7 @@
       ref="year"
       aria-label="Année"
       v-model="year"
-      placeholder="1973"
+      placeholder="AAAA"
       v-select-on-click
       min="1900"
       max="2020">

--- a/src/components/OfflineResults.vue
+++ b/src/components/OfflineResults.vue
@@ -76,6 +76,7 @@ export default {
     getRecap: function(surveyOptin) {
       this.$v.$touch()
       if (this.$v.$invalid) {
+        this.$matomo && this.$matomo.trackEvent('General', 'Invalid form', this.$route.fullPath)
         return
       }
 

--- a/src/views/Foyer/Logement.vue
+++ b/src/views/Foyer/Logement.vue
@@ -310,6 +310,7 @@ export default {
       this.submitted = true
       this.$v.$touch()
       if (this.$v.$invalid) {
+        this.$matomo && this.$matomo.trackEvent('General', 'Invalid form', this.$route.fullPath)
         return
       }
 


### PR DESCRIPTION
Le taux de sortie de la première page du simulateur a augmentée avec le passage à VueJS (de 16 à 18%)

![Screenshot_2020-01-02 mes-aides gouv fr - De 2019-12-23 à 2019-12-29 - Rapports des statistiques web - Matomo](https://user-images.githubusercontent.com/1410356/71663611-33ef9c80-2d56-11ea-97b6-85e1e557b0d0.png)

Il est possible que les personnes ne remplissent pas le seul champ obligatoire qu'est la date de naissance étant donné que des valeurs sont affichées par défaut.
Cette PR remplace ces valeurs par des JJ MM AAAA pour indiquer ce qui est attendu.