### PR TITLE
Enrichie les instructions de contact en cas de blocage

### DIFF
--- a/src/components/BaseLayout.vue
+++ b/src/components/BaseLayout.vue
@@ -14,12 +14,26 @@
                 v-analytics="{ action: 'Envoi d\'email', category:'Blocage'}"
                 v-mail="{to: 'feedback@mes-aides.gouv.fr', subject:'Bloqué·e sur le simulateur', body:`Bonjour,
 
-En utilisant le simulateur Mes Aides, je me suis retrouvé·e bloqué·e.
+En utilisant le simulateur Mes Aides, je me suis retrouvé·e bloqué·e en faisant XXX.
+
+Voici le lien affiché en haut de https://www.whatsmybrowser.org : XXXX.
+
+Vous pouvez me joindre par téléphone au XX XX XX XX XX (de préférence en semaine) pour une dizaine de minutes d'échange afin de comprendre l'origine de mon blocage.
+
+En pièce jointe une capture d'écran pour vous permettre de vous aider à comprendre l'origine du blocage. 
+
+Merci et bonne journée,
 
 ————
 Page : ${$route.fullPath}
-————`}">par email</a> comment vous vous êtes retrouvé·e bloqué·e.
+————`}">par email</a>&nbsp;:
               </p>
+              <ul>
+                <li><strong>comment</strong> vous vous êtes retrouvé·e bloqué·e&nbsp;;</li>
+                <li>le <strong>lien affiché</strong> en haut de <a target="_blank" rel="noopener" href="https://www.whatsmybrowser.org/">la page suivante</a> qui nous permet d'en savoir plus sur votre ordinateur&nbsp;;</li>
+                <li>une capture d'écran si cela vous paraît pertinent et</li>
+                <li>un <strong>numéro de téléphone</strong> auquel nous pouvons vous joindre pour mieux comprendre l'origine de votre blocage.</li>
+              </ul>
               <p>Nous essaierons de vous débloquer et d'éviter que d'autres personnes se retrouvent bloquées comme vous.<p>
 
               <p>


### PR DESCRIPTION
* Pour éviter des emails vides et inactionnables

Trop d'email de « blocage » font l'objet d'un email de réponse demandant plus d'informations.